### PR TITLE
feat(run-jest-file): add function to run entire jest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
                 "title": "Run Jest"
             },
             {
+                "command": "extension.runJestFile",
+                "title": "Run Jest File"
+            },
+            {
                 "command": "extension.debugJest",
                 "title": "Debug Jest"
             }
@@ -55,6 +59,10 @@
             "editor/context": [
                 {
                     "command": "extension.runJest",
+                    "group": "navigation"
+                },
+                {
+                    "command": "extension.runJestFile",
                     "group": "navigation"
                 },
                 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,14 +27,14 @@ export function activate(context: vscode.ExtensionContext) {
     terminal = null;
   });
 
-  const runJest = vscode.commands.registerCommand('extension.runJest', async () => {
+  const execRunJest = async ({ useTestName } = { useTestName: true }) => {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
       return;
     }
 
     const configuration = slash(getConfigPath());
-    const testName = parseTestName(editor);
+    const testName = useTestName ? parseTestName(editor) : '';
     const fileName = slash(editor.document.fileName);
     const jestPath = slash(getJestPath());
 
@@ -54,7 +54,13 @@ export function activate(context: vscode.ExtensionContext) {
     terminal.show();
     await vscode.commands.executeCommand('workbench.action.terminal.clear');
     terminal.sendText(command);
-  });
+  };
+
+  const runJestFile = vscode.commands.registerCommand('extension.runJestFile', async () =>
+    execRunJest({ useTestName: false })
+  );
+
+  const runJest = vscode.commands.registerCommand('extension.runJest', async () => execRunJest());
 
   const debugJest = vscode.commands.registerCommand('extension.debugJest', async () => {
     const editor = vscode.window.activeTextEditor;
@@ -93,6 +99,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   context.subscriptions.push(runJest);
+  context.subscriptions.push(runJestFile);
   context.subscriptions.push(debugJest);
 }
 


### PR DESCRIPTION
Allow user to run jest on entire file when they click `Run Jest File` instead of detecting test path. 

This makes it easier if a user has a key command set up to run jest on their currently opened file, as well as being able to run jest on everything in file, while remaining in the context of their test.

