### PR TITLE
add a runOptions configuration property

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ But if you need to define a external config file use the following config option
 | --- | --- |
 | jestrunner.configPath | Define an external jest-config path to jest (from ${workFolder} e.g. jest-config.json) |
 | jestrunner.jestPath | Define an absolute path to jest (e.g. /usr/lib/node_modules/jest/bin/jest.js) |
+| jestrunner.runOptions | Add or overwrite VScode run options in settings.json  (e.g. "jestrunner.runOptions": { "args": ["--no-cache"] }) |
 
 ## Shortcuts
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
                         "default": "",
                         "description": "Define jest path (optionally)",
                         "scope": "window"
+                    },
+                    "jestrunner.runOptions": {
+                        "type": "object",
+                        "default": {},
+                        "description": "Add or overwrite VScode run options (optionally)",
+                        "scope": "window"
                     }
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const configuration = slash(getConfigPath());
     const testName = parseTestName(editor);
+    const runOptions = vscode.workspace.getConfiguration().get('jestrunner.runOptions')
 
     const config = {
       args: [],
@@ -80,7 +81,8 @@ export function activate(context: vscode.ExtensionContext) {
       name: 'Debug Jest Tests',
       program: getJestPath(),
       request: 'launch',
-      type: 'node'
+      type: 'node',
+      ...runOptions
     };
 
     config.args.push('-i');


### PR DESCRIPTION
I found that I need to add some options to VScode's run config to get breakpoints to work properly, similar to the issues found in this [SO question](https://stackoverflow.com/questions/48998572/jest-babel-in-vs-code-debugger-causes-breakpoints-to-move).

This PR allows users to add or overwrite the default extension config. To get breakpoints working properly in my project, I added:

```json
"jestrunner.runOptions": {
    "args": ["--no-cache"],
    "sourcemaps": "inline",
    "disableOptimisticBPs": true,
}
```

to VScode's `settings.json`

Let me know if you'd like any changes!