### PR TITLE
Fix "jestrunner.runOptions.args" config mutation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,17 +90,20 @@ export function activate(context: vscode.ExtensionContext) {
 
     const configuration = slash(getConfigPath());
     const testName = parseTestName(editor);
-    const runOptions = vscode.workspace.getConfiguration().get('jestrunner.runOptions');
+    const {
+      args: runArgs,
+      ...restRunOptions
+    } = vscode.workspace.getConfiguration().get('jestrunner.runOptions');
 
     const config: any = {
-      args: [],
+      args: runArgs ? [...runArgs] : [],
       console: 'integratedTerminal',
       internalConsoleOptions: 'neverOpen',
       name: 'Debug Jest Tests',
       program: getJestPath(),
       request: 'launch',
       type: 'node',
-      ...runOptions
+      ...restRunOptions
     };
 
     config.args.push('-i');


### PR DESCRIPTION
"Debug Jest" option only works once if you have `jestrunner.runOptions.args` set. On the consecutive runs it will always include previous arguments unless you reload vscode or extension.
This pull request fixes the issue.