### PR TITLE
Remove picture from "Run Jest" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"commands": [
 			{
 				"command": "extension.runJest",
-				"title": "🃏 Run Jest"
+				"title": "Run Jest"
 			},
 			{
 				"command": "extension.runPrevJest",


### PR DESCRIPTION
Popup menus typically don't use pictures.