### PR TITLE
Make test file pattern configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 					},
 					"jestrunner.codeLensSelector": {
 						"type": "string",
-						"default": "**/*.test.{js,jsx,ts,tsx}",
+						"default": "**/*.{test,spec}.{js,jsx,ts,tsx}",
 						"description": "CodeLens will be shown on files matching this pattern"
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
 						"default": false,
 						"description": "Disable CodeLens feature",
 						"scope": "window"
+					},
+					"jestrunner.codeLensSelector": {
+						"type": "string",
+						"default": "**/*.test.{js,jsx,ts,tsx}",
+						"description": "CodeLens will be shown on files matching this pattern"
 					}
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,21 +4,6 @@ import { JestRunner } from './jestRunner';
 import JestRunnerCodeLensProvider from './JestRunnerCodeLensProvider';
 import { JestRunnerConfig } from './jestRunnerConfig';
 
-const docSelectors: vscode.DocumentFilter[] = [
-  {
-    pattern: '**/*.test.tsx'
-  },
-  {
-    pattern: '**/*.test.ts'
-  },
-  {
-    pattern: '**/*.test.js'
-  },
-  {
-    pattern: '**/*.test.jsx'
-  }
-];
-
 export function activate(context: vscode.ExtensionContext) {
   const jestRunner = new JestRunner();
   const codeLensProvider = new JestRunnerCodeLensProvider();
@@ -45,6 +30,9 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   if (!config.isCodeLensDisabled) {
+    const docSelectors: vscode.DocumentFilter[] = [
+      { pattern: vscode.workspace.getConfiguration().get('jestrunner.codeLensSelector') },
+    ];
     const codeLensProviderDisposable = vscode.languages.registerCodeLensProvider(docSelectors, codeLensProvider);
     context.subscriptions.push(codeLensProviderDisposable);
   }


### PR DESCRIPTION
I was disappointed when I updated my extension and the CodeLens disappeared from my project's `.spec.js` files.

This combines the file match selectors into a single selector and makes it a configuration option. It also adds `spec` as a pattern as it's a fairly common scheme.