### PR TITLE
Added projectPath setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
 						"description": "Absolute path to jest bin file (e.g. /usr/lib/node_modules/jest/bin/jest.js)",
 						"scope": "window"
 					},
+					"jestrunner.projectPath": {
+						"type": "string",
+						"default": "",
+						"description": "Absolute path to project directory (e.g. /home/me/project/sub-folder)",
+						"scope": "window"
+					},
 					"jestrunner.debugOptions": {
 						"type": "object",
 						"default": {},

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -70,6 +70,7 @@ export class JestRunner {
       await this.goToProjectDirectory();
       await this.runTerminalCommand(this.previousCommand);
     } else {
+      await this.goToProjectDirectory();
       await this.executeDebugCommand(this.previousCommand);
     }
   }
@@ -84,6 +85,7 @@ export class JestRunner {
 
     const debugCommand = this.getDebugCommand(editor, currentTestName);
 
+    await this.goToProjectDirectory();
     this.executeDebugCommand(debugCommand);
   }
 

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -70,7 +70,6 @@ export class JestRunner {
       await this.goToProjectDirectory();
       await this.runTerminalCommand(this.previousCommand);
     } else {
-      await this.goToProjectDirectory();
       await this.executeDebugCommand(this.previousCommand);
     }
   }
@@ -85,7 +84,6 @@ export class JestRunner {
 
     const debugCommand = this.getDebugCommand(editor, currentTestName);
 
-    await this.goToProjectDirectory();
     this.executeDebugCommand(debugCommand);
   }
 
@@ -107,6 +105,7 @@ export class JestRunner {
       program: this.config.jestBinPath,
       request: 'launch',
       type: 'node',
+      cwd: this.config.projectPath,
       ...this.config.debugOptions
     };
     config.args = config.args ? config.args.slice() : [];

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -37,7 +37,7 @@ export class JestRunner {
 
     this.previousCommand = command;
 
-    await this.goToWorkspaceDirectory();
+    await this.goToProjectDirectory();
     await this.runTerminalCommand(command);
   }
 
@@ -54,7 +54,7 @@ export class JestRunner {
 
     this.previousCommand = command;
 
-    await this.goToWorkspaceDirectory();
+    await this.goToProjectDirectory();
     await this.runTerminalCommand(command);
   }
 
@@ -67,7 +67,7 @@ export class JestRunner {
     await editor.document.save();
 
     if (typeof this.previousCommand === 'string') {
-      await this.goToWorkspaceDirectory();
+      await this.goToProjectDirectory();
       await this.runTerminalCommand(this.previousCommand);
     } else {
       await this.executeDebugCommand(this.previousCommand);
@@ -170,8 +170,8 @@ export class JestRunner {
     return args;
   }
 
-  private async goToWorkspaceDirectory() {
-    await this.runTerminalCommand(`cd ${quote(this.config.currentWorkspaceFolderPath)}`);
+  private async goToProjectDirectory() {
+    await this.runTerminalCommand(`cd ${quote(this.config.projectPath)}`);
   }
 
   private async runTerminalCommand(command: string) {

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -31,6 +31,10 @@ export class JestRunnerConfig {
     return normalizePath(jestPath);
   }
 
+  public get projectPath(): string {
+    return vscode.workspace.getConfiguration().get('jestrunner.projectPath') || this.currentWorkspaceFolderPath;
+  }
+
   public get currentWorkspaceFolderPath() {
     const editor = vscode.window.activeTextEditor;
     return vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -27,7 +27,7 @@ export class JestRunnerConfig {
 
     // default
     const relativeJestBin = isWindows() ? 'node_modules/jest/bin/jest.js' : 'node_modules/.bin/jest';
-    jestPath = path.join(this.currentWorkspaceFolderPath, relativeJestBin);
+    jestPath = path.join(this.projectPath, relativeJestBin);
     return normalizePath(jestPath);
   }
 


### PR DESCRIPTION
This PR allows projects that have the `node_modules` in a different subfolder other than the root workspace folder.