### PR TITLE
Add support for Yarn 2 Pnp

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,18 @@
 						"type": "string",
 						"default": "**/*.{test,spec}.{js,jsx,ts,tsx}",
 						"description": "CodeLens will be shown on files matching this pattern"
+					},
+					"jestrunner.enableYarnPnpSupport": {
+						"type": "boolean",
+						"default": false,
+						"description": "Enable if you are using Yarn 2 with Plug'n'Play",
+						"scope": "window"
+					},
+					"jestrunner.detectYarnPnpJestBin": {
+						"type": "boolean",
+						"default": false,
+						"description": "Auto-detect path on Linux/Unix systems to Jest bin (Yarn 2 Pnp)",
+						"scope": "window"
 					}
 				}
 			}

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -107,6 +107,15 @@ export class JestRunner {
       type: 'node',
       ...this.config.debugOptions
     };
+    if (this.config.isYarnPnpSupportEnabled) {
+      config.runtimeArgs = [
+        '--require',
+        '${workspaceFolder}/.pnp.js',
+      ];
+    }
+    if (this.config.isDetectYarnPnpJestBin) {
+      config.program = this.config.yarnPnpJestBinPath;
+    }
     config.args = config.args ? config.args.slice() : [];
 
     const filePath = editor.document.fileName;

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -15,6 +15,10 @@ export class JestRunnerConfig {
     }
 
     // default
+    if (this.isYarnPnpSupportEnabled) {
+      const pnp = `${this.yarnPnpPath}`;
+      return `node ${pnp} "${this.jestBinPath}"`;
+    }
     return `node ${quote(this.jestBinPath)}`;
   }
 
@@ -28,6 +32,9 @@ export class JestRunnerConfig {
     // default
     const relativeJestBin = isWindows() ? 'node_modules/jest/bin/jest.js' : 'node_modules/.bin/jest';
     jestPath = path.join(this.currentWorkspaceFolderPath, relativeJestBin);
+    if (this.isDetectYarnPnpJestBin) {
+      jestPath = this.yarnPnpJestBinPath;
+    }
     return normalizePath(jestPath);
   }
 
@@ -76,4 +83,23 @@ export class JestRunnerConfig {
     const isCodeLensDisabled: boolean = vscode.workspace.getConfiguration().get('jestrunner.disableCodeLens');
     return isCodeLensDisabled ? isCodeLensDisabled : false;
   }
+
+  public get isYarnPnpSupportEnabled(): boolean {
+    const isYarnPnp: boolean = vscode.workspace.getConfiguration().get('jestrunner.enableYarnPnpSupport');
+    return isYarnPnp ? isYarnPnp : false;
+  }
+
+  public get yarnPnpPath(): string {
+    return `--require ${quote(this.currentWorkspaceFolderPath + '/.pnp.js')}`;
+  }
+
+  public get isDetectYarnPnpJestBin(): boolean {
+    const isDetectYarnPnpJestBin: boolean = vscode.workspace.getConfiguration().get('jestrunner.detectYarnPnpJestBin');
+    return isDetectYarnPnpJestBin ? isDetectYarnPnpJestBin : false;
+  }
+
+  public get yarnPnpJestBinPath(): string {
+    return '`yarn bin jest`';
+  }
+
 }


### PR DESCRIPTION
Hi!

This is an awesome plugin and it works out-of-the-box with no issue but it lacks support for Yarn 2 Pnp ([Plug'n'Play](https://yarnpkg.com/features/pnp)).

So what I have created is a setting where you can enable support for Yarn 2 Pnp:

![screen](https://user-images.githubusercontent.com/3331946/92643407-66409900-f2ea-11ea-9fb6-c050ccbb4425.png)

I believe the settings should be self-explanatory if you look at the source code but here is a quick summary:

- Enable Yarn 2 Pnp support: require `.pnp.js` module when invoking jest command
- Detect Yarn Pnp Jest Bin: unlike Yarn 1, there is no `bin` folder and path returned by `yarn bin` will vary from system-to-system due to how caching works; e.g. on my system `.yarn/cache/jest-cli-npm-26.4.2-046301e896-1dc23b584d.zip/node_modules/jest-cli/bin/jest.js`
  - this option is limited to unix/linux systems as I do not know how to invoke `yarn` on Windows systems (help is welcome!)
- I had to use back ticks for `yarn` command as VSC kept escaping the dollar sign (and could not figure out how to prevent that)

Ps. I have never previously worked with VSC extensions so I imagine my code could be very poor quality; help for refactoring is welcome too!