### PR TITLE
Added dynamic lookup of jest.config.js in workspace file tree

### DIFF
--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { isWindows, normalizePath, quote } from './util';
 
@@ -47,17 +48,29 @@ export class JestRunnerConfig {
     const editor = vscode.window.activeTextEditor;
     return vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;
   }
-
   public get jestConfigPath(): string {
     // custom
     let configPath: string = vscode.workspace.getConfiguration().get('jestrunner.configPath');
     if (!configPath) {
-      return '';
+      return this.findConfigPath();
     }
 
     // default
     configPath = path.join(this.currentWorkspaceFolderPath, configPath);
     return normalizePath(configPath);
+  }
+    
+  private findConfigPath(): string {
+    let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
+    let currentFolderConfigPath: string;
+    do {
+      currentFolderConfigPath = path.join(currentFolderPath, 'jest.config.js');
+      if(fs.existsSync(currentFolderConfigPath)) {
+        return currentFolderConfigPath;
+      }
+      currentFolderPath = path.join(currentFolderPath, '..');
+    } while(currentFolderPath !== this.currentWorkspaceFolderPath);
+    return '';
   }
 
   public get runOptions(): any {


### PR DESCRIPTION
Since I didn't want to configure my config file path for every test I run (I have a multi-package setup), I extended the functionality of the extension by doing a dynamic lookup of the jest.config.js file whenever the configPath isn't set by the user.
It works by traversing the directories upward from the currently active file (until it reaches the workspace folder) and checking for the presence of the jest.config.js file. If no config file is found, the extension behaves as before.