### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Comparison with [vscode-jest](https://github.com/jest-community/vscode-jest)
 
-[vscode-jest-runner](https://github.com/firsttris/vscode-jest-runner) is about running or debugging a sepcific test or test-suite, while [vscode-jest](https://github.com/jest-community/vscode-jest) is about running your current test-suite everytime you change it and it's not possible to run or debug a specific test.
+[vscode-jest-runner](https://github.com/firsttris/vscode-jest-runner) is about running or debugging a specific test or test-suite, while [vscode-jest](https://github.com/jest-community/vscode-jest) is about running your current test-suite everytime you change it and it's not possible to run or debug a specific test.
 
 ## Features
 


### PR DESCRIPTION
line 9 contained 'sepcific' instead of 'specific'