### PR TITLE
Added dynamic lookup of package.json in workspace file tree

### DIFF
--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -44,48 +44,37 @@ export class JestRunnerConfig {
     // custom
     let projectPath: string = vscode.workspace.getConfiguration().get('jestrunner.projectPath');
     if(!projectPath){
-      return this.findProjectPath();
+      return this.findConfigFolderPath();
     }
     // default
     projectPath = path.join(this.currentWorkspaceFolderPath, projectPath )
     return normalizePath(projectPath);
   }
 
-  private findProjectPath(): string {
-    let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
-    let currentFolderProjectPath: string;
-    do {
-      currentFolderProjectPath = path.join(currentFolderPath, 'jest.config.js');
-      if(fs.existsSync(currentFolderProjectPath)) {
-        return currentFolderProjectPath.replace('jest.config.js', '');
-      }
-      currentFolderPath = path.join(currentFolderPath, '..');
-    } while(currentFolderPath !== this.currentWorkspaceFolderPath);
-    return '';
-  }
   public get currentWorkspaceFolderPath() {
     const editor = vscode.window.activeTextEditor;
     return vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;
   }
+
   public get jestConfigPath(): string {
     // custom
     let configPath: string = vscode.workspace.getConfiguration().get('jestrunner.configPath');
-    if (!configPath) {
-      return this.findConfigPath();
+    if(!configPath) {
+      const configFolderPath = this.findConfigFolderPath();
+      return configFolderPath === '' ? '' : path.join(configFolderPath, 'jest.config.js');
     }
-
     // default
     configPath = path.join(this.currentWorkspaceFolderPath, configPath);
     return normalizePath(configPath);
   }
     
-  private findConfigPath(): string {
+  private findConfigFolderPath(): string {
     let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
     let currentFolderConfigPath: string;
     do {
       currentFolderConfigPath = path.join(currentFolderPath, 'jest.config.js');
       if(fs.existsSync(currentFolderConfigPath)) {
-        return currentFolderConfigPath;
+        return currentFolderPath;
       }
       currentFolderPath = path.join(currentFolderPath, '..');
     } while(currentFolderPath !== this.currentWorkspaceFolderPath);

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -41,9 +41,28 @@ export class JestRunnerConfig {
   }
 
   public get projectPath(): string {
-    return vscode.workspace.getConfiguration().get('jestrunner.projectPath') || this.currentWorkspaceFolderPath;
+    // custom
+    let projectPath: string = vscode.workspace.getConfiguration().get('jestrunner.projectPath');
+    if(!projectPath){
+      return this.findProjectPath();
+    }
+    // default
+    projectPath = path.join(this.currentWorkspaceFolderPath, projectPath )
+    return normalizePath(projectPath);
   }
 
+  private findProjectPath(): string {
+    let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
+    let currentFolderProjectPath: string;
+    do {
+      currentFolderProjectPath = path.join(currentFolderPath, 'package.json');
+      if(fs.existsSync(currentFolderProjectPath)) {
+        return currentFolderProjectPath.replace('package.json', '');
+      }
+      currentFolderPath = path.join(currentFolderPath, '..');
+    } while(currentFolderPath !== this.currentWorkspaceFolderPath);
+    return '';
+  }
   public get currentWorkspaceFolderPath() {
     const editor = vscode.window.activeTextEditor;
     return vscode.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath;

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -55,9 +55,9 @@ export class JestRunnerConfig {
     let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
     let currentFolderProjectPath: string;
     do {
-      currentFolderProjectPath = path.join(currentFolderPath, 'package.json');
+      currentFolderProjectPath = path.join(currentFolderPath, 'jest.config.js');
       if(fs.existsSync(currentFolderProjectPath)) {
-        return currentFolderProjectPath.replace('package.json', '');
+        return currentFolderProjectPath.replace('jest.config.js', '');
       }
       currentFolderPath = path.join(currentFolderPath, '..');
     } while(currentFolderPath !== this.currentWorkspaceFolderPath);


### PR DESCRIPTION
Inspired by the pull request made by @vrptnc I added code to dynamically look for the closest package.json, this is because my particular monorepo setup won't trigger tests correctly from the outermost package.json. I reused some code from his jest.config lookup so a set projectPath will take precedence, and if you don't specify a path it'll keep looking until it hits the currentWorkspaceFolderPath where It'll surely find a package.json.