### PR TITLE
Escape single quotes in test names on Linux (#81)

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -1,7 +1,7 @@
 import { parse } from 'jest-editor-support';
 import * as vscode from 'vscode';
 import { JestRunnerConfig } from './jestRunnerConfig';
-import { escapeRegExp, findFullTestName, normalizePath, pushMany, quote, unquote } from './util';
+import { escapeRegExp, escapeSingleQuotes, findFullTestName, normalizePath, pushMany, quote, unquote } from './util';
 
 interface DebugCommand {
   documentUri: vscode.Uri;
@@ -166,7 +166,7 @@ export class JestRunner {
 
     if (testName) {
       args.push('-t');
-      args.push(quoter(testName));
+      args.push(quoter(escapeSingleQuotes(testName)));
     }
 
     const setOptions = new Set(options);

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,6 +41,10 @@ export function exactRegexMatch(s: string): string {
   return ['^', s, '$'].join('');
 }
 
+export function escapeSingleQuotes(s: string): string {
+  return isWindows() ? s : s.replace(/'/g, "'\\''");
+}
+
 export function quote(s: string): string {
   const q = isWindows() ? '"' : `'`;
   return [q, s, q].join('');


### PR DESCRIPTION
Tested manually on Ubuntu. Fixes examples like "tester's test" and other variations.

I wanted to add unit tests but I couldn't get them to run:
```
node_modules/jest-editor-support/index.d.ts:35:2 - error TS1036: Statements are not allowed in ambient contexts.

35 };
    ~
```