### PR TITLE
Escape plus sign in file path

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -1,7 +1,16 @@
 import { parse } from 'jest-editor-support';
 import * as vscode from 'vscode';
 import { JestRunnerConfig } from './jestRunnerConfig';
-import { escapeRegExp, escapeSingleQuotes, findFullTestName, normalizePath, pushMany, quote, unquote } from './util';
+import {
+  escapePlusSign,
+  escapeRegExp,
+  escapeSingleQuotes,
+  findFullTestName,
+  normalizePath,
+  pushMany,
+  quote,
+  unquote,
+} from './util';
 
 interface DebugCommand {
   documentUri: vscode.Uri;
@@ -157,7 +166,7 @@ export class JestRunner {
     const args: string[] = [];
     const quoter = withQuotes ? quote : str => str;
 
-    args.push(quoter(normalizePath(filePath)));
+    args.push(quoter(normalizePath(escapePlusSign(filePath))));
 
     if (this.config.jestConfigPath) {
       args.push('-c');

--- a/src/util.ts
+++ b/src/util.ts
@@ -65,3 +65,7 @@ export function unquote(s: string): string {
 export function pushMany<T>(arr: T[], items: T[]): number {
   return Array.prototype.push.apply(arr, items);
 }
+
+export function escapePlusSign(s: string): string {
+  return s.replace(/[+]/g, '\\$&');
+}


### PR DESCRIPTION
For some reason that I don't understand, Jest can't handle `+` in file paths like `/taormina/libs/data-access-game/src/lib/+state/cards/cards.selectors.spec.ts`.

This is a quick fix to escape the `+` in file paths, wich gives `/taormina/libs/data-access-game/src/lib/\+state/cards/cards.selectors.spec.ts`.

This setup can be found in any Nrwl Nx project managing Ngrx state, as the `+` is scripted in the schematics. 