### PR TITLE
Use node_modules to find the project path

### DIFF
--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -41,7 +41,18 @@ export class JestRunnerConfig {
   }
 
   public get projectPath(): string {
-    return vscode.workspace.getConfiguration().get('jestrunner.projectPath') || this.currentWorkspaceFolderPath;
+    let projPath: string = vscode.workspace.getConfiguration().get('jestrunner.projectPath');
+    if (projPath) {
+      return projPath;
+    }
+
+    const configPath = this.findConfigPath();
+    const configDir = path.dirname(configPath);
+    if (fs.existsSync(path.join(configDir, 'node_modules'))) {
+      return configDir;
+    }
+
+    return this.currentWorkspaceFolderPath;
   }
 
   public get currentWorkspaceFolderPath() {


### PR DESCRIPTION
If you have a monorepo containing multiple projects, you may still have
the entire repo open as a single VS Code workspace. In that case, you
may have multiple node_modules, jest.config.js, babel.config.js, etc.
all within the same VS Code workspace.

Previously, this extension would find the correct jest.config.js but
would then run jest from the top-level workspace folder, which would
cause it to miss the correct babel.config.js (and possibly to miss the
jest binary altogether, if it is not also present in a top-level
node_modules).

This commit causes the extension to use the same logic to find the
project path as it already uses to find the jest config. If there is no
node_modules folder at the same level as the jest config, then it falls
back to the previous behaviour of just using the VS Code workspace
folder.