### PR TITLE
resolve jest test name string interpolation for test pattern such as test.each

### DIFF
--- a/src/test/suite/findFullTestName.test.ts
+++ b/src/test/suite/findFullTestName.test.ts
@@ -2,7 +2,7 @@ import { parse } from 'jest-editor-support';
 import * as path from 'path';
 import { findFullTestName } from '../../util';
 
-const children = parse(path.resolve(__dirname, 'test2.test.js')).root.children;
+const children = parse(path.resolve(__dirname, 'test2.test.ts')).root.children;
 
 it('should find line 1', () => {
   expect(findFullTestName(1, children)).toBe('testSuiteA');
@@ -20,11 +20,22 @@ it('should find line 13', () => {
   expect(findFullTestName(13, children)).toBe('testSuiteA test2 should run this test');
 });
 
-it('should find line 23', () => {
-  expect(findFullTestName(23, children)).toBe('testSuiteB lol');
-  expect(findFullTestName(24, children)).toBe('testSuiteB lol');
+it('should find line 17', () => {
+  expect(findFullTestName(17, children)).toBe('testSuiteA test2 test3');
 });
 
-it('should find line 17', () => {
-  expect(findFullTestName(17, children)).toBe('testSuiteA test2 test3 should run this test 3');
+it('should find line 18', () => {
+  expect(findFullTestName(18, children)).toBe('testSuiteA test2 test3 should run this test 3');
+});
+
+it('should find line 37', () => {
+  expect(findFullTestName(35, children)).toBe('(.*?) + (.*?) returned value not be less than (.*?)');
+});
+
+it('should find line 42', () => {
+  expect(findFullTestName(42, children)).toBe('returns (.*?) when (.*?) is added (.*?)');
+});
+
+it('should find line 50', () => {
+  expect(findFullTestName(50, children)).toBe('.add((.*?), (.*?)) returns (.*?)');
 });

--- a/src/test/suite/test2.test.ts
+++ b/src/test/suite/test2.test.ts
@@ -27,3 +27,27 @@ describe('testSuiteB', () => {
     expect(true).toBe(true);
   });
 });
+
+describe.each`
+  a    | b    | expected
+  ${1} | ${1} | ${2}
+`('$a + $b', ({a, b, expected}) => {
+  test(`returned value not be less than ${expected}`, () => {
+    expect(a + b).not.toBeLessThan(expected);
+  });
+});
+
+test.each`
+  a    | b    | expected
+  ${1} | ${1} | ${2}
+`('returns $expected when $a is added $b', ({a, b, expected}) => {
+    expect(a + b).toBe(expected); // will not be ran
+});
+
+describe.each([
+  [1, 1, 2],
+])('.add(%i, %i)', (a, b, expected) => {
+  test(`returns ${expected}`, () => {
+    expect(a + b).toBe(expected);
+  });
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,8 @@ export function normalizePath(path: string): string {
 }
 
 export function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+  var escapedString =  s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+  return escapedString.replace(/\\\(\\\.\\\*\\\?\\\)/g, '(.*?)'); // should revert the escaping of match all regex patterns.
 }
 
 export function findFullTestName(selectedLine: number, children: any[]): string | undefined {
@@ -16,16 +17,16 @@ export function findFullTestName(selectedLine: number, children: any[]): string 
   }
   for (const element of children) {
     if (element.type === 'describe' && selectedLine === element.start.line) {
-      return element.name;
+      return resolveTestNameStringInterpolation(element.name);
     }
     if (element.type !== 'describe' && selectedLine >= element.start.line && selectedLine <= element.end.line) {
-      return element.name;
+      return resolveTestNameStringInterpolation(element.name);
     }
   }
   for (const element of children) {
     const result = findFullTestName(selectedLine, element.children);
     if (result) {
-      return element.name + ' ' + result;
+      return resolveTestNameStringInterpolation(element.name) + ' ' + result;
     }
   }
 }
@@ -36,6 +37,12 @@ const QUOTES = {
   '\'': true,
   '`': true
 };
+
+export function resolveTestNameStringInterpolation(s: string): string {
+  const variableRegex = /(\${?[A-Za-z0-9_]+}?|%[psdifjo#%])/ig;
+  const matchAny = '(.*?)';
+  return s.replace(variableRegex, matchAny);
+}
 
 export function exactRegexMatch(s: string): string {
   return ['^', s, '$'].join('');


### PR DESCRIPTION
- added a function to resolve the string interpolation in test names, replacing variable name, printf patterns with regex match all expression.
- Added and updated tests for findFullTestName function.

for example, for test name 
"check result should be ${expected}"
since the variable will be resolved at run time, so using -t with the variable name will not match the test, so this PR added a function to convert it to 
"check result should be (.*?)"

A more specific case: say when i am running the following test.
![image](https://user-images.githubusercontent.com/78626456/112554375-659dba80-8d83-11eb-9087-c1122027d8eb.png)

before change
![image](https://user-images.githubusercontent.com/78626456/112554725-10ae7400-8d84-11eb-9b18-f82d4dc1993f.png)

because the variable in the test name , jest fail to find matching test case.

after change 
![image](https://user-images.githubusercontent.com/78626456/112554146-fde76f80-8d82-11eb-91b4-61a9850e9cae.png)
