### PR TITLE
Add explorer menus to run and debug tests with jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,16 @@
 					"command": "extension.debugJest",
 					"group": "02_jest"
 				}
+			],
+			"explorer/context": [
+				{
+					"command": "extension.runJest",
+					"group": "02_jest@1"
+				},
+				{
+					"command": "extension.debugJest",
+					"group": "02_jest@2"
+				}
 			]
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -138,10 +138,12 @@
 			"explorer/context": [
 				{
 					"command": "extension.runJest",
+					"when": "explorerResourceIsFolder || resourceFilename =~ /.*\\.(spec|test)\\.(js|jsx|ts|tsx)$/",
 					"group": "02_jest@1"
 				},
 				{
 					"command": "extension.debugJest",
+					"when": "explorerResourceIsFolder || resourceFilename =~ /.*\\.(spec|test)\\.(js|jsx|ts|tsx)$/",
 					"group": "02_jest@2"
 				}
 			]

--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
 				"title": "Run Jest"
 			},
 			{
+				"command": "extension.runJestPath",
+				"title": "Run Jest"
+			},
+			{
 				"command": "extension.runJestAndUpdateSnapshots",
 				"title": "Run Jest and Update Snapshots"
 			},
@@ -117,6 +121,10 @@
 			},
 			{
 				"command": "extension.debugJest",
+				"title": "Debug Jest"
+			},
+			{
+				"command": "extension.debugJestPath",
 				"title": "Debug Jest"
 			},
 			{
@@ -137,12 +145,12 @@
 			],
 			"explorer/context": [
 				{
-					"command": "extension.runJest",
+					"command": "extension.runJestPath",
 					"when": "explorerResourceIsFolder || resourceFilename =~ /.*\\.(spec|test)\\.(js|jsx|ts|tsx)$/",
 					"group": "02_jest@1"
 				},
 				{
-					"command": "extension.debugJest",
+					"command": "extension.debugJestPath",
 					"when": "explorerResourceIsFolder || resourceFilename =~ /.*\\.(spec|test)\\.(js|jsx|ts|tsx)$/",
 					"group": "02_jest@2"
 				}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,28 +9,30 @@ export function activate(context: vscode.ExtensionContext) {
   const codeLensProvider = new JestRunnerCodeLensProvider();
   const config = new JestRunnerConfig();
 
-  const runJest = vscode.commands.registerCommand('extension.runJest', async (argument: object | string | {path: string}) => {
+  const runJest = vscode.commands.registerCommand('extension.runJest', async (argument: object | string ) => {
     if (typeof argument === 'string') {
       jestRunner.runCurrentTest(argument);
-    } else if('path' in argument) {
-      jestRunner.runTestsOnPath(argument.path)
     } else {
       jestRunner.runCurrentTest();
     }
   });
+  const runJestPath = vscode.commands.registerCommand('extension.runJestPath', async (argument: vscode.Uri) => 
+    jestRunner.runTestsOnPath(argument.path)
+  );
   const runJestAndUpdateSnapshots = vscode.commands.registerCommand('extension.runJestAndUpdateSnapshots', async () => {
       jestRunner.runCurrentTest('', ['-u']);
   });
   const runJestFile = vscode.commands.registerCommand('extension.runJestFile', async () => jestRunner.runCurrentFile());
-  const debugJest = vscode.commands.registerCommand('extension.debugJest', async (argument: object | string | {path: string}) => {
+  const debugJest = vscode.commands.registerCommand('extension.debugJest', async (argument: object | string ) => {
     if (typeof argument === 'string') {
       jestRunner.debugCurrentTest(argument)
-    } else if('path' in argument) {
-      jestRunner.debugTestsOnPath(argument.path);
     } else {
       jestRunner.debugCurrentTest()
     }
   });
+  const debugJestPath = vscode.commands.registerCommand('extension.debugJestPath', async (argument: vscode.Uri) => 
+    jestRunner.debugTestsOnPath(argument.path)
+  );
   const runPrev = vscode.commands.registerCommand('extension.runPrevJest', async () => jestRunner.runPreviousTest());
   const runJestFileWithCoverage = vscode.commands.registerCommand('extension.runJestFileWithCoverage', async () =>
     jestRunner.runCurrentFile(['--coverage'])
@@ -46,7 +48,9 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(runJest);
   context.subscriptions.push(runJestAndUpdateSnapshots);
   context.subscriptions.push(runJestFile);
+  context.subscriptions.push(runJestPath);
   context.subscriptions.push(debugJest);
+  context.subscriptions.push(debugJestPath);
   context.subscriptions.push(runPrev);
   context.subscriptions.push(runJestFileWithCoverage);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,9 +9,11 @@ export function activate(context: vscode.ExtensionContext) {
   const codeLensProvider = new JestRunnerCodeLensProvider();
   const config = new JestRunnerConfig();
 
-  const runJest = vscode.commands.registerCommand('extension.runJest', async (argument: object | string) => {
+  const runJest = vscode.commands.registerCommand('extension.runJest', async (argument: object | string | {path: string}) => {
     if (typeof argument === 'string') {
       jestRunner.runCurrentTest(argument);
+    } else if('path' in argument) {
+      jestRunner.runTestsOnPath(argument.path)
     } else {
       jestRunner.runCurrentTest();
     }
@@ -20,9 +22,11 @@ export function activate(context: vscode.ExtensionContext) {
       jestRunner.runCurrentTest('', ['-u']);
   });
   const runJestFile = vscode.commands.registerCommand('extension.runJestFile', async () => jestRunner.runCurrentFile());
-  const debugJest = vscode.commands.registerCommand('extension.debugJest', async (argument: object | string) => {
+  const debugJest = vscode.commands.registerCommand('extension.debugJest', async (argument: object | string | {path: string}) => {
     if (typeof argument === 'string') {
       jestRunner.debugCurrentTest(argument)
+    } else if('path' in argument) {
+      jestRunner.debugTestsOnPath(argument.path);
     } else {
       jestRunner.debugCurrentTest()
     }

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -86,9 +86,20 @@ export class JestRunnerConfig {
     // default
     return normalizePath(path.join(this.currentWorkspaceFolderPath, configPath));
   }
+
+  getJestConfigPath(targetPath: string) {
+    // custom
+    const configPath: string = vscode.workspace.getConfiguration().get('jestrunner.configPath');
+    if (!configPath) {
+      return this.findConfigPath(targetPath);
+    }
+
+    // default
+    return normalizePath(path.join(this.currentWorkspaceFolderPath, configPath));
+  }
     
-  private findConfigPath(): string {
-    let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
+  private findConfigPath(targetPath?: string): string {
+    let currentFolderPath: string = targetPath || path.dirname(vscode.window.activeTextEditor.document.fileName);
     let currentFolderConfigPath: string;
     do {
       currentFolderConfigPath = path.join(currentFolderPath, 'jest.config.js');


### PR DESCRIPTION
Add explorer context menus for running tests under a folder

![Captura de tela de 2021-03-31 11-35-02](https://user-images.githubusercontent.com/32395904/113162293-89df1880-9215-11eb-8b39-54c0a356023a.png)

Also works in files

![Captura de tela de 2021-03-31 11-36-07](https://user-images.githubusercontent.com/32395904/113162497-bbf07a80-9215-11eb-8cc0-bfe0ac009934.png)
