### PR TITLE
fix: fix issue when jest is not installed at the root of the project

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -46,7 +46,7 @@ export class JestRunner {
 
     this.previousCommand = command;
 
-    await this.goToProjectDirectory();
+    await this.goToCwd();
     await this.runTerminalCommand(command);
   }
 
@@ -63,7 +63,7 @@ export class JestRunner {
 
     this.previousCommand = command;
 
-    await this.goToProjectDirectory();
+    await this.goToCwd();
     await this.runTerminalCommand(command);
   }
 
@@ -76,7 +76,7 @@ export class JestRunner {
     await editor.document.save();
 
     if (typeof this.previousCommand === 'string') {
-      await this.goToProjectDirectory();
+      await this.goToCwd();
       await this.runTerminalCommand(this.previousCommand);
     } else {
       this.executeDebugCommand(this.previousCommand);
@@ -114,7 +114,7 @@ export class JestRunner {
       program: this.config.jestBinPath,
       request: 'launch',
       type: 'node',
-      cwd: this.config.projectPath,
+      cwd: this.config.cwd,
       ...this.config.debugOptions
     };
     if (this.config.isYarnPnpSupportEnabled) {
@@ -189,8 +189,8 @@ export class JestRunner {
     return args;
   }
 
-  private async goToProjectDirectory() {
-    await this.runTerminalCommand(`cd ${quote(this.config.projectPath)}`);
+  private async goToCwd() {
+    await this.runTerminalCommand(`cd ${quote(this.config.cwd)}`);
   }
 
   private async runTerminalCommand(command: string) {


### PR DESCRIPTION
Hi,

This is my attempt to fix #135 (already tested on a personnal project).
Basically, instead of returning the root of the project as the current working directory, I try to detect where jest is "really" installed (starting at the file path, go up until I find `node_modules/jest` binary), so that we can run it from there.

Close #135

[EDIT]: Just saw #143, please let me know if this PR is still relevant ;)