### PR TITLE
escape special characters in test filepath (#114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Another vscode instance will open with the just compiled extension installed.
 - By default **Jest** finds its config from the `"jest"` attribute in your `package.json` or if you export an object `module.export = {}` in a `jest.config.js` file in your project root directory.   
 Read More: [Configuring Jest Docs](https://jestjs.io/docs/en/configuration)
 
-- If Breakspoints are not working properly, try adding this to vscode config:
+- If Breakpoints are not working properly, try adding this to vscode config:
 
 ```javascript
 "jestrunner.debugOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-jest-runner",
-	"version": "0.4.33",
+	"version": "0.4.34",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -40,7 +40,7 @@ export class JestRunner {
 
     await editor.document.save();
 
-    const filePath = editor.document.fileName;
+    const filePath = escapeRegExp(editor.document.fileName);
     const testName = currentTestName || this.findCurrentTestName(editor);
     const command = this.buildJestCommand(filePath, testName, options);
 

--- a/src/test/suite/[test2]+more.test.ts
+++ b/src/test/suite/[test2]+more.test.ts
@@ -1,0 +1,12 @@
+/**
+ * This test file is created specifically to test square brackets `[]`
+ * and plus symbols `+` in the file path.
+ */
+
+describe('testSuiteWithSpecialCharactersInFilePath', () => {
+    describe('test 1', () => {
+      it('should run this test', () => {
+        expect(true).toBe(true);
+      });
+    });
+});


### PR DESCRIPTION
This escapes special characters to allow tests to be run even if they have special characters in the test file filepath.

This fixes the issue when running the development (debugging mode). I've attempted to add a test, although I was unable to get the tests on `master` passing as-is, so I've not made much progress with this. My concern with the addition of this test is that it might just be ignored if the new behaviour is reverted, and as it won't be run it won't fail.