### PR TITLE
Instructions to use extension on a CRA project without adding files to the source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,41 +27,23 @@ Run & Debug your Jest Tests from
 
 ![Extension Example](https://github.com/firsttris/vscode-jest/raw/master/public/vscode-jest.gif)
 
-## Usage with CRA or similar abstractions
+## Usage with Create React App / CRA
 
-add the following command to settings, to pass commandline arguments
+Add the following command to settings, to run tests
 ```
 "jestrunner.jestCommand": "npm run test --"
 ```
 
-## Debugging JSX/TSX with CRA
-
-for debugging JST/TSX with CRA you need to have a valid babel and jest config: 
-
-to add a `babel.config.js` with at least the following config
+Add the following commands to settings, to debug tests
 ```
-// babel.config.js
-module.exports = {
-    presets: [
-      ["@babel/preset-env", { targets: { node: "current" } }],
-      "babel-preset-react-app",
-    ],
-  };
-```
-
-add a `jest.config.js` with at least the following config
-
-```
-module.exports = {
-  transform: {
-    '\\.(js|ts|jsx|tsx)$': 'babel-jest',
-    '\\.(jpg|jpeg|png|gif|ico|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|webmanifest|xml)$':
-      '<rootDir>/jest/fileTransformer.js'
-  },
-  moduleNameMapper: {
-    '\\.(css)$': 'identity-obj-proxy'
-  },
-}
+"jestrunner.jestPath": "${workspaceRoot}/node_modules/.bin/react-scripts",
+"jestrunner.debugOptions": {
+		"args": ["test", "--no-cache"],
+		"disableOptimisticBPs": true,
+		"env": {
+			"CI": "true"
+		},
+	},
 ```
 
 Check that debugger works:


### PR DESCRIPTION
The extension does not work with CRA.
Adding these commands to settings.json makes both Run and Debug to work.