### PR TITLE
Fix path for yarn 2 release file

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -145,7 +145,7 @@ export class JestRunner {
 
     if (this.config.isYarnPnpSupportEnabled) {
       config.args = ['jest'];
-      config.program = '.yarn/releases/yarn-*.js';
+      config.program = '.yarn/releases/yarn-*.*js';
     }
 
     const standardArgs = this.buildJestArgs(filePath, currentTestName, false);

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -145,7 +145,7 @@ export class JestRunner {
 
     if (this.config.isYarnPnpSupportEnabled) {
       config.args = ['jest'];
-      config.program = '.yarn/releases/yarn-*.cjs';
+      config.program = '.yarn/releases/yarn-*.js';
     }
 
     const standardArgs = this.buildJestArgs(filePath, currentTestName, false);


### PR DESCRIPTION
When clicking `Debug` in a test suite of a project that is using yarn 2 PNP, the extension currently fails to launch the debug process as it is attempting to launch yarn using the path `.yarn/releases/yarn-*.cjs`. The release file that yarn creates, however, uses the pattern `yarn-*.js`, as can be seen below:

```
▶ ls -lah .yarn/releases 
total 1.6M
drwxrwxr-x 2 rob rob 4.0K Jun 22 21:37 .
drwxrwxr-x 7 rob rob 4.0K Jun 22 21:37 ..
-rwxrwxr-x 1 rob rob 1.6M Jun 22 21:37 yarn-berry.js
```

This pull request changes the path to be inline with the file extension that yarn creates the release file with, which fixes launching debug sessions.