### PR TITLE
Add config option to preserve editor focus on test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If you have a custom setup use the following options to configure Jest Runner:
 | jestrunner.enableYarnPnpSupport | Enable if you are using Yarn 2 with Plug'n'Play |
 | jestrunner.projectPath | Absolute path to project directory (e.g. /home/me/project/sub-folder) |
 | jestrunner.changeDirectoryToWorkspaceRoot | Changes directory to workspace root before executing the test |
+| jestrunner.preserveEditorFocus | Preserve focus on your editor instead of focusing the terminal on test run |
 
 ## Shortcuts
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,12 @@
             "default": true,
             "description": "Changes directory to workspace root before executing the test",
             "scope": "window"
+          },
+          "jestrunner.preserveEditorFocus": {
+            "type": "boolean",
+            "default": false,
+            "description": "Preserve focus on editor when running tests",
+            "scope": "window"
           }
         }
       }

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -213,7 +213,7 @@ export class JestRunner {
     if (!this.terminal) {
       this.terminal = vscode.window.createTerminal('jest');
     }
-    this.terminal.show();
+    this.terminal.show(this.config.preserveEditorFocus);
     await vscode.commands.executeCommand('workbench.action.terminal.clear');
     this.terminal.sendText(command);
   }

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -26,6 +26,10 @@ export class JestRunnerConfig {
     return vscode.workspace.getConfiguration().get('jestrunner.changeDirectoryToWorkspaceRoot');
   }
 
+  public get preserveEditorFocus(): boolean {
+    return vscode.workspace.getConfiguration().get('jestrunner.preserveEditorFocus') || false;
+  }
+
   public get jestBinPath(): string {
     // custom
     let jestPath: string = vscode.workspace.getConfiguration().get('jestrunner.jestPath');


### PR DESCRIPTION
Add configuration option `preserveEditorFocus` to preserve focus on your editor when running specs.

Adding the config:

```json
{
  "jestRunner.preserveEditorFocus": true
}
```

...will preserve focus on your editor, instead of focusing the terminal, when a Jest test run is started. This is a helpful option available in test runners for other languages (such as the very popular [Code Runner](https://marketplace.visualstudio.com/items?itemName=formulahendry.code-runner) extension), and is great for vim-like workflows.

Preserving focus is accomplished simply by passing the config value to the `preserveFocus?` argument of the [`Terminal`](https://code.visualstudio.com/api/references/vscode-api#Terminal) `.show()` method, with a default of `false`.

I did not see a relevant place to add a spec, but am happy to provide one.

Closes https://github.com/firsttris/vscode-jest-runner/issues/97