### PR TITLE
fix: missing import for CodeLensOption

### DIFF
--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { isWindows, normalizePath, quote, validateCodeLensOptions } from './util';
+import { CodeLensOption, isWindows, normalizePath, quote, validateCodeLensOptions } from './util';
 
 export class JestRunnerConfig {
   /**


### PR DESCRIPTION
Noticed a missing import when attempting to Run > Start Debugging as documented

```ERROR in /Users/nir.gilboa/vscode-jest-runner/src/jestRunnerConfig.ts
./src/jestRunnerConfig.ts 150:32-46
[tsl] ERROR in /Users/nir.gilboa/learning/vscode-jest-runner/src/jestRunnerConfig.ts(150,33)
      TS2304: Cannot find name 'CodeLensOption'.
ts-loader-default_e3b0c44298fc1c14
 @ ./src/extension.ts 16:27-56```