### PR TITLE
fix: valid jestBinPath is js file

### DIFF
--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { CodeLensOption, isWindows, normalizePath, quote, validateCodeLensOptions } from './util';
+import { CodeLensOption, isNodeExecuteAbleFile, normalizePath, quote, validateCodeLensOptions } from './util';
 
 export class JestRunnerConfig {
   /**
@@ -38,10 +38,12 @@ export class JestRunnerConfig {
     }
 
     // default
-    const relativeJestBin = isWindows() ? 'node_modules/jest/bin/jest.js' : 'node_modules/.bin/jest';
+    const fallbackRelativeJestBinPath = 'node_modules/jest/bin/jest.js';
+    const mayRelativeJestBin = ['node_modules/.bin/jest', 'node_modules/jest/bin/jest.js'];
     const cwd = this.cwd;
 
-    jestPath = path.join(cwd, relativeJestBin);
+    jestPath = mayRelativeJestBin.find((relativeJestBin) => isNodeExecuteAbleFile(path.join(cwd, relativeJestBin)));
+    jestPath = jestPath || path.join(cwd, fallbackRelativeJestBinPath);
 
     return normalizePath(jestPath);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'child_process';
+
 export function isWindows(): boolean {
   return process.platform.includes('win32');
 }
@@ -88,4 +90,13 @@ function isCodeLensOption(option: string): option is CodeLensOption {
 
 export function validateCodeLensOptions(maybeCodeLensOptions: string[]): CodeLensOption[] {
   return [...new Set(maybeCodeLensOptions)].filter((value) => isCodeLensOption(value)) as CodeLensOption[];
+}
+
+export function isNodeExecuteAbleFile(filepath: string): boolean {
+  try {
+    execSync(`node ${filepath} --help`);
+    return true;
+  } catch (err) {
+    return false;
+  }
 }


### PR DESCRIPTION
when repo use pnpm, 'node_modules/.bin/jest' is not js file, pnpm will auto generate bash file instead of original js file, so add valid for 'node_modules/.bin/jest' file，if not valid use 'node_modules/jest/bin/jest.js' instead
fix #119 