### PR TITLE
Adding test reference by filename pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,12 @@
             "description": "Define an alternative Jest command (e.g. for Create React App and similar abstractions)",
             "scope": "window"
           },
+          "jestrunner.useTestPatternAsFileName": {
+            "type": "boolean",
+            "default": false,
+            "description": "The test will be referenced as 'my-test.test' instead of '/path/to/my-test.test.ts'.",
+            "scope": "window"
+          },
           "jestrunner.disableCodeLens": {
             "type": "boolean",
             "default": false,

--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -181,7 +181,15 @@ export class JestRunner {
     const args: string[] = [];
     const quoter = withQuotes ? quote : (str) => str;
 
-    args.push(quoter(escapeRegExpForPath(normalizePath(filePath))));
+    const useTestPatternAsFileName = this.config.useTestPatternAsFileName;
+    let testReference: string = escapeRegExpForPath(normalizePath(filePath));
+
+    if (useTestPatternAsFileName) {
+      testReference = /([^\\/]*(?=[.][a-zA-Z]+$))/g.exec(testReference)[0];
+      if (!testReference) throw new Error('Could not find test name reference');
+    }
+
+    args.push(quoter(testReference));
 
     const jestConfigPath = this.config.getJestConfigPath(filePath);
     if (jestConfigPath) {

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -22,6 +22,10 @@ export class JestRunnerConfig {
     return `node ${quote(this.jestBinPath)}`;
   }
 
+  public get useTestPatternAsFileName(): boolean {
+    return vscode.workspace.getConfiguration().get('jestrunner.useTestPatternAsFileName');
+  }
+
   public get changeDirectoryToWorkspaceRoot(): boolean {
     return vscode.workspace.getConfiguration().get('jestrunner.changeDirectoryToWorkspaceRoot');
   }


### PR DESCRIPTION
Dear all. This is because my Jest installation, using typescript, can't call the test by the full path of the .ts file. My need as to have only the name of the test, so that Jest could find it by the pattern in the dist folder. So, I did this change by adding a new configuration parameter to enable/disable this behavior.