### PR TITLE
fix: Run only tests with a name that matches the regex

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -216,7 +216,7 @@ export class JestRunner {
 
     if (testName) {
       args.push('-t');
-      args.push(quoter(escapeSingleQuotes(testName)));
+      args.push(quoter(escapeSingleQuotes(`^${testName}$`)));
     }
 
     const setOptions = new Set(options);


### PR DESCRIPTION
```js
describe('my pr', () => {
  it('should run this test', () => {

  })
  it('should run this test, however jest run this beacause it finally match this test name', () => {

  })
})
```