### PR TITLE
chore: support jest.config.cjs

### DIFF
--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -108,7 +108,7 @@ export class JestRunnerConfig {
     let currentFolderPath: string = targetPath || path.dirname(vscode.window.activeTextEditor.document.fileName);
     let currentFolderConfigPath: string;
     do {
-      for (const configFilename of ['jest.config.js', 'jest.config.ts']) {
+      for (const configFilename of ['jest.config.js', 'jest.config.ts', 'jest.config.cjs']) {
         currentFolderConfigPath = path.join(currentFolderPath, configFilename);
 
         if (fs.existsSync(currentFolderConfigPath)) {


### PR DESCRIPTION
As stated in the [Jest Docs](https://jestjs.io/docs/configuration)
> It is recommended to define the configuration in a dedicated JavaScript, TypeScript or JSON file. The file will be discovered automatically, if it is named jest.config.js|ts|mjs|cjs|json

This PR adds only `.cjs` extension as I didn't want to deal with the possible complexity that comes with other file extensions.