### PR TITLE
fix: execution error when testName contains quotes and parentheses

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -6,6 +6,7 @@ import {
   escapeRegExp,
   escapeRegExpForPath,
   escapeSingleQuotes,
+  escapeTestName,
   findFullTestName,
   normalizePath,
   pushMany,
@@ -59,7 +60,7 @@ export class JestRunner {
     await editor.document.save();
 
     const filePath = editor.document.fileName;
-    const testName = currentTestName || this.findCurrentTestName(editor);
+    const testName = escapeTestName(currentTestName || this.findCurrentTestName(editor));
     const command = this.buildJestCommand(filePath, testName, options);
 
     this.previousCommand = command;

--- a/src/util.ts
+++ b/src/util.ts
@@ -57,6 +57,10 @@ export function escapeSingleQuotes(s: string): string {
   return isWindows() ? s : s.replace(/'/g, "'\\''");
 }
 
+export function escapeTestName(s: string): string {
+  return isWindows() ? s.replace(/"/g, "'") : s.replace(/'/g, '"');
+}
+
 export function quote(s: string): string {
   const q = isWindows() ? '"' : `'`;
   return [q, s, q].join('');


### PR DESCRIPTION
The following test case, when I click the `Run` button to execute, the terminal will throw an error.
```ts
describe('a "(name)"', () => {
  it('b', () => {
    expect(1).toBe(1);
  })
});
```