### PR TITLE
Fix when properties in test name

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -11,6 +11,7 @@ import {
   pushMany,
   quote,
   unquote,
+  updateTestNameIfUsingProperties,
 } from './util';
 
 interface DebugCommand {
@@ -60,7 +61,8 @@ export class JestRunner {
 
     const filePath = editor.document.fileName;
     const testName = currentTestName || this.findCurrentTestName(editor);
-    const command = this.buildJestCommand(filePath, testName, options);
+    const resolvedTestName = updateTestNameIfUsingProperties(testName);
+    const command = this.buildJestCommand(filePath, resolvedTestName, options);
 
     this.previousCommand = command;
 
@@ -129,7 +131,8 @@ export class JestRunner {
 
     const filePath = editor.document.fileName;
     const testName = currentTestName || this.findCurrentTestName(editor);
-    const debugConfig = this.getDebugConfig(filePath, testName);
+    const resolvedTestName = updateTestNameIfUsingProperties(testName);
+    const debugConfig = this.getDebugConfig(filePath, resolvedTestName);
 
     await this.goToCwd();
     await this.executeDebugCommand({

--- a/src/util.ts
+++ b/src/util.ts
@@ -100,3 +100,11 @@ export function isNodeExecuteAbleFile(filepath: string): boolean {
     return false;
   }
 }
+
+export function updateTestNameIfUsingProperties(receivedTestName: string) {
+  const namePropertyRegex = /(?<=\S)\\.name/g;
+  const testNameWithoutNameProperty = receivedTestName.replace(namePropertyRegex, '');
+
+  const prototypePropertyRegex = /\w*\\.prototype\\./g;
+  return testNameWithoutNameProperty.replace(prototypePropertyRegex, '');
+}


### PR DESCRIPTION
Fixes #299

_Full disclosure: I've never worked on this, or any, VS Code extension before.  I'm also not a pro at the jest command line.  No worries if this needs more work!_

There are still a few weird edge cases that I'm not sure how to get around.   It seems to me that the core of the problem is that VSCode passes a string to the extension handlers, regardless of whether or not a string (as opposed to a symbol) is used in the test name. 

For example, the following test will not be captured by the CodeLens option in the extension after my change:
```typescript
it('has.name randomly in it', () => {...});
```
or maybe a bit more realistically, this one would not be captured either:
```typescript
it('The method MyClass.prototype.myMethod exists', () => {...});
```

On the whole, I still think this is a considerable improvement from current functionality, and will allow me to use the extension in work projects where I currently can't.  :)  