### PR TITLE
Relative path for `jestrunner.projectPath`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.platform }}
 
     strategy:
       matrix:
         node-version: [16.x]
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you have a custom setup use the following options to configure Jest Runner:
 | jestrunner.codeLens | Choose which CodeLens to enable, default to `["run", "debug"]` |
 | jestrunner.enableYarnPnpSupport Enable if you are using Yarn 2 with Plug'n'Play |  
 | jestrunner.yarnPnpCommand | Command for debugging with Plug'n'Play defaults to yarn-*.*js |
-| jestrunner.projectPath | Absolute path to project directory (e.g. /home/me/project/sub-folder), or relative path (e.g. ./sub-folder) |
+| jestrunner.projectPath | Absolute path to project directory (e.g. /home/me/project/sub-folder), or relative path to workspace root (e.g. ./sub-folder) |
 | jestrunner.changeDirectoryToWorkspaceRoot | Changes directory to workspace root before executing the test |
 | jestrunner.preserveEditorFocus | Preserve focus on your editor instead of focusing the terminal on test run |
 | jestrunner.runInExternalNativeTerminal | run in external terminal (requires: npm install ttab -g) |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you have a custom setup use the following options to configure Jest Runner:
 | jestrunner.codeLens | Choose which CodeLens to enable, default to `["run", "debug"]` |
 | jestrunner.enableYarnPnpSupport Enable if you are using Yarn 2 with Plug'n'Play |  
 | jestrunner.yarnPnpCommand | Command for debugging with Plug'n'Play defaults to yarn-*.*js |
-| jestrunner.projectPath | Absolute path to project directory (e.g. /home/me/project/sub-folder) |
+| jestrunner.projectPath | Absolute path to project directory (e.g. /home/me/project/sub-folder), or relative path (e.g. ./sub-folder) |
 | jestrunner.changeDirectoryToWorkspaceRoot | Changes directory to workspace root before executing the test |
 | jestrunner.preserveEditorFocus | Preserve focus on your editor instead of focusing the terminal on test run |
 | jestrunner.runInExternalNativeTerminal | run in external terminal (requires: npm install ttab -g) |

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  moduleNameMapper: {
+    '^vscode$': 'src/test/__mocks__/vscode.ts',
+  },
 };

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -49,15 +49,18 @@ export class JestRunnerConfig {
   }
 
   public get projectPath(): string {
-    return vscode.workspace.getConfiguration().get('jestrunner.projectPath') || this.currentWorkspaceFolderPath;
+    return this.projectPathFromConfig || this.currentWorkspaceFolderPath;
   }
 
   public get cwd(): string {
-    return (
-      vscode.workspace.getConfiguration().get('jestrunner.projectPath') ||
-      this.currentPackagePath ||
-      this.currentWorkspaceFolderPath
-    );
+    return this.projectPathFromConfig || this.currentPackagePath || this.currentWorkspaceFolderPath;
+  }
+
+  public get projectPathFromConfig(): string | undefined {
+    const projectPathFromConfig = vscode.workspace.getConfiguration().get('jestrunner.projectPath');
+    if (projectPathFromConfig) {
+      return path.resolve(this.currentWorkspaceFolderPath, projectPathFromConfig as string);
+    }
   }
 
   private get currentPackagePath() {

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -57,9 +57,9 @@ export class JestRunnerConfig {
   }
 
   public get projectPathFromConfig(): string | undefined {
-    const projectPathFromConfig = vscode.workspace.getConfiguration().get('jestrunner.projectPath');
+    const projectPathFromConfig = vscode.workspace.getConfiguration().get<string>('jestrunner.projectPath');
     if (projectPathFromConfig) {
-      return path.resolve(this.currentWorkspaceFolderPath, projectPathFromConfig as string);
+      return path.resolve(this.currentWorkspaceFolderPath, projectPathFromConfig);
     }
   }
 

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -1,0 +1,62 @@
+// __mocks__/vscode.ts
+
+class Uri {
+  constructor(readonly fsPath: string) {}
+}
+
+class Document {
+  constructor(public readonly uri: Uri) {}
+}
+
+class TextEditor {
+  constructor(public readonly document: Document) {}
+}
+
+class WorkspaceFolder {
+  constructor(public readonly uri: Uri) {}
+
+  name: string;
+  index: number;
+}
+
+class Workspace {
+  getWorkspaceFolder(uri: Uri): { uri: Uri } {
+    return { uri };
+  }
+
+  getConfiguration() {
+    throw new WorkspaceConfiguration({});
+  }
+}
+
+class WorkspaceConfiguration {
+  constructor(private dict: { [key: string]: string }) {}
+
+  get(key: string): string {
+    if (!(key in this.dict)) {
+      throw new Error(`unrecognised config key ${key}`);
+    }
+    return this.dict[key];
+  }
+
+  has(key: string) {
+    return key in this.dict;
+  }
+  inspect(section: string): undefined {
+    throw new Error('not implemented');
+  }
+  update(key: string, value: string): Thenable<void> {
+    throw new Error('not implemented');
+  }
+}
+
+class Window {
+  get activeTextEditor(): TextEditor {
+    return new TextEditor(new Document(new Uri('hi')));
+  }
+}
+
+const workspace = new Workspace();
+const window = new Window();
+
+export { workspace, window, Uri, Document, TextEditor, WorkspaceFolder, WorkspaceConfiguration };

--- a/src/test/jestRunnerConfig.test.ts
+++ b/src/test/jestRunnerConfig.test.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+import { JestRunnerConfig } from '../jestRunnerConfig';
+import { Uri, WorkspaceConfiguration, WorkspaceFolder } from './__mocks__/vscode';
+
+const describes = {
+  windows: process.platform === 'win32' ? describe : describe.skip,
+  linux: ['linux', 'darwin'].includes(process.platform) ? describe : describe.skip,
+};
+
+describe('JestRunnerConfig', () => {
+  describes.windows('Windows style paths', () => {
+    let jestRunnerConfig: JestRunnerConfig;
+    beforeEach(() => {
+      jestRunnerConfig = new JestRunnerConfig();
+      jest
+        .spyOn(vscode.workspace, 'getWorkspaceFolder')
+        .mockReturnValue(new WorkspaceFolder(new Uri('C:\\project') as any) as any);
+    });
+
+    it.each([
+      ['absolute path (with \\)', 'C:\\project\\jestProject'],
+      ['absolute path (with /)', 'C:/project/jestProject'],
+      ['relative path', './jestProject'],
+    ])('%s', (_testName, projectPath) => {
+      jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+        new WorkspaceConfiguration({
+          'jestrunner.projectPath': projectPath,
+        })
+      );
+
+      expect(jestRunnerConfig.projectPath).toBe('C:\\project\\jestProject');
+    });
+  });
+
+  describes.linux('Linux style paths', () => {
+    let jestRunnerConfig: JestRunnerConfig;
+
+    beforeEach(() => {
+      jestRunnerConfig = new JestRunnerConfig();
+      jest
+        .spyOn(vscode.workspace, 'getWorkspaceFolder')
+        .mockReturnValue(new WorkspaceFolder(new Uri('/home/user/project') as any) as any);
+    });
+
+    it.each([
+      ['absolute path', '/home/user/project/jestProject'],
+      ['relative path', './jestProject'],
+    ])('%s', (_testName, projectPath) => {
+      jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+        new WorkspaceConfiguration({
+          'jestrunner.projectPath': projectPath,
+        })
+      );
+
+      expect(jestRunnerConfig.projectPath).toBe('/home/user/project/jestProject');
+    });
+  });
+});


### PR DESCRIPTION
Hello 👋

I wanted to enhance `jestrunner.projectPath` to accept a path relative to the workspace root.

My use case is a repository where jest needs to be run from a folder that isn't the root (in combination with "Change Directory To Workspace Root"). I'm trying to bundle a `.vscode/settings` with the repository, so using an absolute path is not ideal for me because developers clone the repo in different folders.

I saw that it was done previously in https://github.com/firsttris/vscode-jest-runner/pull/111 and then later reverted. It looks like this is the relevant commit: https://github.com/firsttris/vscode-jest-runner/commit/60e0d6291e0877fc4e1e78fae4c02d964a6894e3#r107914911. 

Seems like the extension has changed a bit since then, what do you think of this change? Thanks
