### PR TITLE
Quote for both run and debug so it.each works

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -177,7 +177,7 @@ export class JestRunner {
       config.program = `.yarn/releases/${this.config.getYarnPnpCommand}`;
     }
 
-    const standardArgs = this.buildJestArgs(filePath, currentTestName, false);
+    const standardArgs = this.buildJestArgs(filePath, currentTestName, true);
     pushMany(config.args, standardArgs);
     config.args.push('--runInBand');
 


### PR DESCRIPTION
``` typescript
it.each([1,2,3,4])('should parse and generate %i and generate it again', id => {
...
})
```

Will generate the following command run:

```
node 'node_modules/.bin/jest' '/Users/tlb/git/connectedcars/ingester-tl-v2/src/lib/traffilog-parser/tools/monitor-csv-parser.test.ts' -t 'parser should parse and generate (.*?) and generate it again'
```

and the following command with debug:
```
... node node_modules/.bin/jest --testTimeout=100000000 --detectOpenHandles /Users/tlb/git/connectedcars/ingester-tl-v2/src/lib/traffilog-parser/tools/monitor-csv-parser.test.ts -t parser\ should\ parse\ and\ generate\ \(.\*?\)\ and\ generate\ it\ again --runInBand 
```

Resulting in:
```
zsh: no matches found: parser should parse and generate setting (.*?) and generate it again
```