### PR TITLE
fix: :bug: new escape regex for line breaks using template strings on…

### DIFF
--- a/src/jestRunner.ts
+++ b/src/jestRunner.ts
@@ -4,6 +4,7 @@ import { JestRunnerConfig } from './jestRunnerConfig';
 import { parse } from './parser';
 import {
   escapeRegExp,
+  escapeRegExpForLineBreaks,
   escapeRegExpForPath,
   escapeSingleQuotes,
   findFullTestName,
@@ -218,7 +219,7 @@ export class JestRunner {
 
     if (testName) {
       args.push('-t');
-      args.push(quoter(escapeSingleQuotes(testName)));
+      args.push(quoter(escapeRegExpForLineBreaks(escapeSingleQuotes(testName))));
     }
 
     const setOptions = new Set(options);

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,6 +17,10 @@ export function escapeRegExpForPath(s: string): string {
   return s.replace(/[*+?^${}<>()|[\]]/g, '\\$&'); // $& means the whole matched string
 }
 
+export function escapeRegExpForLineBreaks(s: string): string {
+  return s.replace(/\n/g, '\\n');
+}
+
 export function findFullTestName(selectedLine: number, children: any[]): string | undefined {
   if (!children) {
     return;


### PR DESCRIPTION
This PR fix the following issue:

When there's a line break on the test name using template string, the debugger button will run other tests, not only the intended test.
This bug is only occurring on linux, but I think it can also happen on Windows. My friend has a mac and the bug doesn't happen on his OS.
The bug will make the Jest-runner CLI command erase everything after the line break on the test name.

Test name example:
it(`should return error`
`when there is no product`, async () => { } )

it(`should return error`
`when there is no category`, async () => { } )

Issue #318 