### PR TITLE
docs: Update to clarify `jestrunner.configPath` and `jestrunner.changeDirectoryToWorkspaceRoot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,22 @@ add the following command to settings:
 Jest Runner will work out of the box, with a valid Jest config.
 If you have a custom setup use the following options to customize Jest Runner:
 
-| Command | Description |
-| --- | --- |
-| jestrunner.configPath | Jest config path (relative to ${workFolder} e.g. jest-config.json) |
-| jestrunner.jestPath | Absolute path to jest bin file (e.g. /usr/lib/node_modules/jest/bin/jest.js) |
-| jestrunner.debugOptions | Add or overwrite vscode debug configurations (only in debug mode) (e.g. `"jestrunner.debugOptions": { "args": ["--no-cache"] }`) |
-| jestrunner.runOptions | Add CLI Options to the Jest Command (e.g. `"jestrunner.runOptions": ["--coverage", "--colors"]`) https://jestjs.io/docs/en/cli |
-| jestrunner.jestCommand | Define an alternative Jest command (e.g. for Create React App and similar abstractions) |
-| jestrunner.disableCodeLens | Disable CodeLens feature |
-| jestrunner.codeLensSelector | CodeLens will be shown on files matching this pattern (default **/*.{test,spec}.{js,jsx,ts,tsx}) |
-| jestrunner.codeLens | Choose which CodeLens to enable, default to `["run", "debug"]` |
-| jestrunner.enableYarnPnpSupport | Enable if you are using Yarn 2 with Plug'n'Play |
-| jestrunner.yarnPnpCommand | Command for debugging with Plug'n'Play defaults to yarn-*.*js |
-| jestrunner.projectPath | Absolute path to project directory (e.g. /home/me/project/sub-folder), or relative path to workspace root (e.g. ./sub-folder) |
-| jestrunner.changeDirectoryToWorkspaceRoot | Changes directory to workspace root before executing the test |
-| jestrunner.preserveEditorFocus | Preserve focus on your editor instead of focusing the terminal on test run |
-| jestrunner.runInExternalNativeTerminal | run in external terminal (requires: npm install ttab -g) |
+| Command                                   | Description                                                                                                                                                 |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| jestrunner.configPath                     | Jest config path (relative to `${workspaceFolder}` e.g. jest-config.json)                                                                                   |
+| jestrunner.jestPath                       | Absolute path to jest bin file (e.g. /usr/lib/node_modules/jest/bin/jest.js)                                                                                |
+| jestrunner.debugOptions                   | Add or overwrite vscode debug configurations (only in debug mode) (e.g. `"jestrunner.debugOptions": { "args": ["--no-cache"] }`)                            |
+| jestrunner.runOptions                     | Add CLI Options to the Jest Command (e.g. `"jestrunner.runOptions": ["--coverage", "--colors"]`) https://jestjs.io/docs/en/cli                              |
+| jestrunner.jestCommand                    | Define an alternative Jest command (e.g. for Create React App and similar abstractions)                                                                     |
+| jestrunner.disableCodeLens                | Disable CodeLens feature                                                                                                                                    |
+| jestrunner.codeLensSelector               | CodeLens will be shown on files matching this pattern (default **/*.{test,spec}.{js,jsx,ts,tsx})                                                            |
+| jestrunner.codeLens                       | Choose which CodeLens to enable, default to `["run", "debug"]`                                                                                              |
+| jestrunner.enableYarnPnpSupport           | Enable if you are using Yarn 2 with Plug'n'Play                                                                                                             |
+| jestrunner.yarnPnpCommand                 | Command for debugging with Plug'n'Play defaults to yarn-*.*js                                                                                               |
+| jestrunner.projectPath                    | Absolute path to project directory (e.g. /home/me/project/sub-folder), or relative path to workspace root (e.g. ./sub-folder)                               |
+| jestrunner.changeDirectoryToWorkspaceRoot | Changes directory before execution. The order is:<ol><li>`jestrunner.projectPath`</li><li>the nearest `package.json`</li><li>`${workspaceFolder}`</li></ol> |
+| jestrunner.preserveEditorFocus            | Preserve focus on your editor instead of focusing the terminal on test run                                                                                  |
+| jestrunner.runInExternalNativeTerminal    | run in external terminal (requires: npm install ttab -g)                                                                                                    |
 
 ## Shortcuts
 
@@ -75,7 +75,7 @@ Command Pallette -> Preferences: Open Keyboard Shortcuts (JSON)
 the json config file will open
 add this:
 
-```javascript
+```json
 {
   "key": "alt+1",
   "command": "extension.runJest"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
           "jestrunner.configPath": {
             "type": "string",
             "default": "",
-            "description": "Jest config path (relative to ${workFolder} e.g. jest-config.json)",
+            "description": "Jest config path (relative to `${workspaceFolder}` e.g. jest-config.json)",
             "scope": "window"
           },
           "jestrunner.jestPath": {
@@ -105,9 +105,9 @@
           "jestrunner.changeDirectoryToWorkspaceRoot": {
             "type": "boolean",
             "default": true,
-            "description": "Changes directory to workspace root before executing the test",
+            "description": "Changes directory before execution. The fallback order is:\n1. `jestrunner.projectPath`\n2. the nearest `package.json`\n3. `${workspaceFolder}`",
             "scope": "window"
-          },
+          },          
           "jestrunner.preserveEditorFocus": {
             "type": "boolean",
             "default": false,


### PR DESCRIPTION
* Use ${workspaceFolder} instead of ${workFolder}, closes #342
* Clarify `changeDirectoryToWorkspaceRoot` fallback order, closes #340