### PR TITLE
Add code lens option for `collectCoverageFrom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
               "run",
               "debug"
             ],
-            "description": "Enable desired codeLens, possible value : 'run', 'debug', 'watch', 'coverage'. Defaults to ['run', 'debug'] ",
+            "description": "Enable desired codeLens, possible value : 'run', 'debug', 'watch', 'coverage', 'current-test-coverage'. Defaults to ['run', 'debug'] ",
             "items": {
               "type": "string",
-              "description": "Either 'run', 'debug', 'watch', 'coverage'"
+              "description": "Either 'run', 'debug', 'watch', 'coverage', 'current-test-coverage'"
             },
             "scope": "window"
           },

--- a/src/JestRunnerCodeLensProvider.ts
+++ b/src/JestRunnerCodeLensProvider.ts
@@ -8,12 +8,14 @@ function getCodeLensForOption(range: Range, codeLensOption: CodeLensOption, full
     debug: 'Debug',
     watch: 'Run --watch',
     coverage: 'Run --coverage',
+    'current-test-coverage': 'Run --collectCoverageFrom (target file/dir)'
   };
   const commandMap: Record<CodeLensOption, string> = {
     run: 'extension.runJest',
     debug: 'extension.debugJest',
     watch: 'extension.watchJest',
     coverage: 'extension.runJestCoverage',
+    'current-test-coverage': 'extension.runJestCurrentTestCoverage'
   };
   return new CodeLens(range, {
     arguments: [fullTestName],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,13 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   );
 
+  const runJestCurrentTestCoverage = vscode.commands.registerCommand(
+    'extension.runJestCurrentTestCoverage',
+    async (argument: Record<string, unknown> | string) => {
+      return jestRunner.runCurrentTest(argument, ['--coverage'], true);
+    }
+  );
+
   const runJestPath = vscode.commands.registerCommand('extension.runJestPath', async (argument: vscode.Uri) =>
     jestRunner.runTestsOnPath(argument.path)
   );
@@ -71,6 +78,7 @@ export function activate(context: vscode.ExtensionContext): void {
   }
   context.subscriptions.push(runJest);
   context.subscriptions.push(runJestCoverage);
+  context.subscriptions.push(runJestCurrentTestCoverage);
   context.subscriptions.push(runJestAndUpdateSnapshots);
   context.subscriptions.push(runJestFile);
   context.subscriptions.push(runJestPath);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,13 @@
+import * as path from 'path';
 import { execSync } from 'child_process';
+
+export function getDirName(filePath: string): string {
+  return path.dirname(filePath);
+}
+
+export function getFileName(filePath: string): string {
+  return path.basename(filePath);
+}
 
 export function isWindows(): boolean {
   return process.platform.includes('win32');
@@ -74,10 +83,10 @@ export function pushMany<T>(arr: T[], items: T[]): number {
   return Array.prototype.push.apply(arr, items);
 }
 
-export type CodeLensOption = 'run' | 'debug' | 'watch' | 'coverage';
+export type CodeLensOption = 'run' | 'debug' | 'watch' | 'coverage' | 'current-test-coverage';
 
 function isCodeLensOption(option: string): option is CodeLensOption {
-  return ['run', 'debug', 'watch', 'coverage'].includes(option);
+  return ['run', 'debug', 'watch', 'coverage', 'current-test-coverage'].includes(option);
 }
 
 export function validateCodeLensOptions(maybeCodeLensOptions: string[]): CodeLensOption[] {


### PR DESCRIPTION
- add a code lens option: `'current-test-coverage'`
- this options will add two args to jest command:
  - `--coverage`
  - `--collectCoverageFrom` with a glob pattern which is either:
    - current test file name minus ".test" or ".spec", prefixed with `**/`; OR
    - if that file doesn't exist the directory name of current test file, prefixed with `**/` and appended with `/**`

example 1:
file tree:
```
dir1
|_app.test.ts
|_app.ts
```
in this case the arg added will be `--collectCoverageFrom "**/app.ts"`


example 2:
file tree:
```
dir1
|_dir2
  |_apps.test.ts
  |_app1.ts
  |_app2.ts
```
in this case the arg added will be `--collectCoverageFrom "**/dir2/**"`
