### PR TITLE
Update package.json search not to check for `node_modules/jest`

### DIFF
--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -62,12 +62,9 @@ export class JestRunnerConfig {
   private get currentPackagePath() {
     let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
     do {
-      // Try to find where jest is installed relatively to the current opened file.
-      // Do not assume that jest is always installed at the root of the opened project, this is not the case
-      // such as in multi-module projects.
+      // Find the nearest package.json file, which would be the folder where the user normally runs commands for this file
       const pkg = path.join(currentFolderPath, 'package.json');
-      const jest = path.join(currentFolderPath, 'node_modules', 'jest');
-      if (fs.existsSync(pkg) && fs.existsSync(jest)) {
+      if (fs.existsSync(pkg)) {
         return currentFolderPath;
       }
       currentFolderPath = path.join(currentFolderPath, '..');


### PR DESCRIPTION
Modern package managers like pnpm and yarn might not even create that file, and it's not clear whether that is significant.  The presence of a package.json should be enough to indicate that is the place to run commands from.