### PR TITLE
Feature: Implement #309 create jestrunner.configPath mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you have a custom setup use the following options to customize Jest Runner:
 
 | Command                                   | Description                                                                                                                                                 |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| jestrunner.configPath                     | Jest config path (relative to `${workspaceFolder}` e.g. jest-config.json)                                                                                   |
+| jestrunner.configPath                     | Jest config path (string) (relative to `${workspaceFolder}` e.g. jest-config.json). Defaults to blank. Can also be a glob path mapping. See [below](#configpath-as-glob-map) for more details         |
 | jestrunner.jestPath                       | Absolute path to jest bin file (e.g. /usr/lib/node_modules/jest/bin/jest.js)                                                                                |
 | jestrunner.debugOptions                   | Add or overwrite vscode debug configurations (only in debug mode) (e.g. `"jestrunner.debugOptions": { "args": ["--no-cache"] }`)                            |
 | jestrunner.runOptions                     | Add CLI Options to the Jest Command (e.g. `"jestrunner.runOptions": ["--coverage", "--colors"]`) https://jestjs.io/docs/en/cli                              |
@@ -69,6 +69,20 @@ If you have a custom setup use the following options to customize Jest Runner:
 | jestrunner.changeDirectoryToWorkspaceRoot | Changes directory before execution. The order is:<ol><li>`jestrunner.projectPath`</li><li>the nearest `package.json`</li><li>`${workspaceFolder}`</li></ol> |
 | jestrunner.preserveEditorFocus            | Preserve focus on your editor instead of focusing the terminal on test run                                                                                  |
 | jestrunner.runInExternalNativeTerminal    | run in external terminal (requires: npm install ttab -g)                                                                                                    |
+
+### configPath as glob map
+If you've got multiple jest configs for running tests (ie maybe a config for unit tests, integration tests and frontend tests) then this option is for you. You can provide a map of glob matchers to specify which jest config to use based on the name of the file the test is being run for. 
+
+For instance, supose you're using the naming convention of `*.spec.ts` for unit tests and `*.it.spec.ts` for integration tests. You'd use the following for your configPath setting:
+```json
+{
+  "jestrunner.configPath": {
+    "**/*.it.spec.ts": "./jest.it.config.js",
+    "**/*.spec.ts": "./jest.unit.config.js"
+  }
+}
+```
+Note the order we've specified the globs in this example. Because our naming convention has a little overlap, we need to specify the more narrow glob first because jestrunner will return the config path of the first matching glob. With the above order, we make certain that `jest.it.config.js` will be used for any file ending with `.it.spec.ts` and `jest.unit.config.js` will be used for files that only end in `*.spec.ts` (without `.it.`).  If we had reversed the order, `jest.unit.config.js` would be used for both `*.it.spec.ts` and `*.spec.ts` endings the glob matches both. 
 
 ## Shortcuts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.3",
-        "jest-editor-support": "^31.1.2"
+        "jest-editor-support": "^31.1.2",
+        "micromatch": "^4.0.8"
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,25 @@
         "title": "Jest-Runner Config",
         "properties": {
           "jestrunner.configPath": {
-            "type": "string",
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "Jest config path (relative to `${workspaceFolder}` e.g. jest-config.json)"
+              },
+              {
+                "type": "object",
+                "scope": "resource",
+                "description": "A mapping of file globs to jest config paths. Useful when you need to run different jest configurations based on the file naming convention.",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string",
+                    "description": "The target jest config path for the matched file glob."
+                  }
+                },
+                "additionalProperties": false
+              }
+            ],
             "default": "",
-            "description": "Jest config path (relative to `${workspaceFolder}` e.g. jest-config.json)",
             "scope": "window"
           },
           "jestrunner.jestPath": {
@@ -244,6 +260,7 @@
   },
   "dependencies": {
     "fast-glob": "^3.3.3",
-    "jest-editor-support": "^31.1.2"
+    "jest-editor-support": "^31.1.2",
+    "micromatch": "^4.0.8"
   }
 }

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -1,7 +1,15 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { normalizePath, quote, validateCodeLensOptions, CodeLensOption, isNodeExecuteAbleFile } from './util';
+import {
+  normalizePath,
+  quote,
+  validateCodeLensOptions,
+  CodeLensOption,
+  isNodeExecuteAbleFile,
+  resolveConfigPathOrMapping,
+  searchPathToParent,
+} from './util';
 
 export class JestRunnerConfig {
   /**
@@ -59,27 +67,25 @@ export class JestRunnerConfig {
     }
   }
 
-  private get currentPackagePath() {
-    let currentFolderPath: string = path.dirname(vscode.window.activeTextEditor.document.fileName);
+  public get currentPackagePath() {
     const checkRelativePathForJest = vscode.workspace
       .getConfiguration()
       .get<boolean>('jestrunner.checkRelativePathForJest');
-
-    do {
-      // Try to find where jest is installed relatively to the current opened file.
-      // Do not assume that jest is always installed at the root of the opened project, this is not the case
-      // such as in multi-module projects.
-      const pkg = path.join(currentFolderPath, 'package.json');
-      const jest = path.join(currentFolderPath, 'node_modules', 'jest');
-
-      if (fs.existsSync(pkg) && (fs.existsSync(jest) || !checkRelativePathForJest)) {
-        return currentFolderPath;
-      }
-
-      currentFolderPath = path.join(currentFolderPath, '..');
-    } while (currentFolderPath !== this.currentWorkspaceFolderPath);
-
-    return '';
+    const foundPath = searchPathToParent<string>(
+      path.dirname(vscode.window.activeTextEditor.document.uri.fsPath),
+      this.currentWorkspaceFolderPath,
+      (currentFolderPath: string) => {
+        // Try to find where jest is installed relatively to the current opened file.
+        // Do not assume that jest is always installed at the root of the opened project, this is not the case
+        // such as in multi-module projects.
+        const pkg = path.join(currentFolderPath, 'package.json');
+        const jest = path.join(currentFolderPath, 'node_modules', 'jest');
+        if (fs.existsSync(pkg) && (fs.existsSync(jest) || !checkRelativePathForJest)) {
+          return currentFolderPath;
+        }
+      },
+    );
+    return foundPath || '';
   }
 
   private get currentWorkspaceFolderPath(): string {
@@ -89,29 +95,40 @@ export class JestRunnerConfig {
 
   public getJestConfigPath(targetPath: string): string {
     // custom
-    const configPath: string = vscode.workspace.getConfiguration().get('jestrunner.configPath');
+    const configPathOrMapping: string | Record<string, string> | undefined = vscode.workspace
+      .getConfiguration()
+      .get('jestrunner.configPath');
+
+    const configPath = resolveConfigPathOrMapping(configPathOrMapping, targetPath);
     if (!configPath) {
       return this.findConfigPath(targetPath);
     }
 
     // default
-    return normalizePath(path.join(this.currentWorkspaceFolderPath, configPath));
+    return normalizePath(path.resolve(this.currentWorkspaceFolderPath, this.projectPathFromConfig || '', configPath));
   }
 
-  private findConfigPath(targetPath?: string): string {
-    let currentFolderPath: string = targetPath || path.dirname(vscode.window.activeTextEditor.document.fileName);
-    let currentFolderConfigPath: string;
-    do {
-      for (const configFilename of ['jest.config.js', 'jest.config.ts', 'jest.config.cjs', 'jest.config.mjs', 'jest.config.json']) {
-        currentFolderConfigPath = path.join(currentFolderPath, configFilename);
+  public findConfigPath(targetPath?: string): string {
+    const foundPath = searchPathToParent<string>(
+      targetPath || path.dirname(vscode.window.activeTextEditor.document.uri.fsPath),
+      this.currentWorkspaceFolderPath,
+      (currentFolderPath: string) => {
+        for (const configFilename of [
+          'jest.config.js',
+          'jest.config.ts',
+          'jest.config.cjs',
+          'jest.config.mjs',
+          'jest.config.json',
+        ]) {
+          const currentFolderConfigPath = path.join(currentFolderPath, configFilename);
 
-        if (fs.existsSync(currentFolderConfigPath)) {
-          return currentFolderConfigPath;
+          if (fs.existsSync(currentFolderConfigPath)) {
+            return currentFolderConfigPath;
+          }
         }
-      }
-      currentFolderPath = path.join(currentFolderPath, '..');
-    } while (currentFolderPath !== this.currentWorkspaceFolderPath);
-    return '';
+      },
+    );
+    return foundPath ? normalizePath(foundPath) : '';
   }
 
   public get runOptions(): string[] | null {
@@ -121,7 +138,7 @@ export class JestRunnerConfig {
         return runOptions;
       } else {
         vscode.window.showWarningMessage(
-          'Please check your vscode settings. "jestrunner.runOptions" must be an Array. '
+          'Please check your vscode settings. "jestrunner.runOptions" must be an Array. ',
         );
       }
     }

--- a/src/jestRunnerConfig.ts
+++ b/src/jestRunnerConfig.ts
@@ -85,7 +85,7 @@ export class JestRunnerConfig {
         }
       },
     );
-    return foundPath || '';
+    return foundPath ? normalizePath(foundPath) : '';
   }
 
   private get currentWorkspaceFolderPath(): string {

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -29,10 +29,15 @@ class Workspace {
   }
 }
 
+type JestRunnerConfigProps = {
+  'jestrunner.projectPath'?: string;
+  'jestrunner.configPath'?: string | Record<string, string>;
+  'jestrunner.checkRelativePathForJest'?: boolean;
+};
 class WorkspaceConfiguration {
-  constructor(private dict: { [key: string]: string }) {}
+  constructor(private dict: JestRunnerConfigProps) {}
 
-  get(key: string): string {
+  get<T extends keyof typeof this.dict>(key: T): (typeof this.dict)[T] {
     if (!(key in this.dict)) {
       throw new Error(`unrecognised config key ${key}`);
     }
@@ -53,6 +58,9 @@ class WorkspaceConfiguration {
 class Window {
   get activeTextEditor(): TextEditor {
     return new TextEditor(new Document(new Uri('hi')));
+  }
+  showWarningMessage<T extends string>(message: string, ...items: T[]): Thenable<T | undefined> {
+    return Promise.resolve(undefined);
   }
 }
 

--- a/src/test/jestRunnerConfig.test.ts
+++ b/src/test/jestRunnerConfig.test.ts
@@ -514,7 +514,7 @@ describe('JestRunnerConfig', () => {
       [
         'windows',
         'jest dep installed in same path as the opened file',
-        'returns the folder path of the opened file',
+        'returns the (normalized) folder path of the opened file',
         'C:\\workspace',
         'C:\\workspace\\jestProject\\src\\index.it.spec.js',
         'C:\\workspace\\jestProject\\src',
@@ -522,7 +522,7 @@ describe('JestRunnerConfig', () => {
       [
         'windows',
         'jest dep installed in parent path of the opened file',
-        'returns the folder path of the parent of the opened file',
+        'returns the (normalized) folder path of the parent of the opened file',
         'C:\\workspace',
         'C:\\workspace\\jestProject\\src\\index.it.spec.js',
         'C:\\workspace\\jestProject',
@@ -530,7 +530,7 @@ describe('JestRunnerConfig', () => {
       [
         'windows',
         'jest dep installed in an ancestor path of the opened file',
-        'returns the folder path of the ancestor of the opened file',
+        'returns the (normalized) folder path of the ancestor of the opened file',
         'C:\\workspace',
         'C:\\workspace\\jestProject\\deeply\\nested\\package\\src\\index.it.spec.js',
         'C:\\workspace\\jestProject',
@@ -538,7 +538,7 @@ describe('JestRunnerConfig', () => {
       [
         'windows',
         'jest dep installed in the workspace of the opened file',
-        "returns the folder path of the opened file's workspace",
+        "returns the (normalized) folder path of the opened file's workspace",
         'C:\\workspace',
         'C:\\workspace\\jestProject\\src\\index.it.spec.js',
         'C:\\workspace',
@@ -583,7 +583,7 @@ describe('JestRunnerConfig', () => {
 
       its[_os](behavior, async () => {
         if (installedPath) {
-          expect(jestRunnerConfig.currentPackagePath).toBe(installedPath);
+          expect(jestRunnerConfig.currentPackagePath).toBe(normalizePath(installedPath));
         } else {
           expect(jestRunnerConfig.currentPackagePath).toBe('');
         }
@@ -600,7 +600,7 @@ describe('JestRunnerConfig', () => {
 
         its[_os](behavior, async () => {
           if (installedPath) {
-            expect(jestRunnerConfig.currentPackagePath).toBe(installedPath);
+            expect(jestRunnerConfig.currentPackagePath).toBe(normalizePath(installedPath));
           } else {
             expect(jestRunnerConfig.currentPackagePath).toBe('');
           }

--- a/src/test/jestRunnerConfig.test.ts
+++ b/src/test/jestRunnerConfig.test.ts
@@ -1,11 +1,18 @@
 import * as vscode from 'vscode';
 import { JestRunnerConfig } from '../jestRunnerConfig';
-import { Uri, WorkspaceConfiguration, WorkspaceFolder } from './__mocks__/vscode';
-import { isWindows } from '../util';
+import { Document, TextEditor, Uri, WorkspaceConfiguration, WorkspaceFolder } from './__mocks__/vscode';
+import { isWindows, normalizePath } from '../util';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const describes = {
   windows: isWindows() ? describe : describe.skip,
   linux: ['linux', 'darwin'].includes(process.platform) ? describe : describe.skip,
+};
+
+const its = {
+  windows: isWindows() ? it : it.skip,
+  linux: ['linux', 'darwin'].includes(process.platform) ? it : it.skip,
 };
 
 describe('JestRunnerConfig', () => {
@@ -26,7 +33,7 @@ describe('JestRunnerConfig', () => {
       jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
         new WorkspaceConfiguration({
           'jestrunner.projectPath': projectPath,
-        })
+        }),
       );
 
       expect(jestRunnerConfig.cwd).toBe('C:\\project\\jestProject');
@@ -50,10 +57,725 @@ describe('JestRunnerConfig', () => {
       jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
         new WorkspaceConfiguration({
           'jestrunner.projectPath': projectPath,
-        })
+        }),
       );
 
       expect(jestRunnerConfig.cwd).toBe('/home/user/project/jestProject');
+    });
+  });
+
+  describe('getJestConfigPath', () => {
+    describe('configPath is a string', () => {
+      const scenarios: Array<
+        [
+          os: 'windows' | 'linux',
+          name: string,
+          behavior: string,
+          workspacePath: string,
+          projectPath: string | undefined,
+          configPath: string,
+          targetPath: string,
+          expectedPath: string,
+        ]
+      > = [
+        [
+          'linux',
+          'configPath is an absolute path',
+          'returned path is only the specified config path',
+          '/home/user/workspace',
+          './jestProject',
+          '/home/user/notWorkspace/notJestProject/jest.config.js',
+          '/home/user/workspace/jestProject/src/index.test.js',
+          '/home/user/notWorkspace/notJestProject/jest.config.js',
+        ],
+        [
+          'linux',
+          'configPath is a relative path, project path is set',
+          'returned path is resolved against workspace and project path',
+          '/home/user/workspace',
+          './jestProject',
+          './jest.config.js',
+          '/home/user/workspace/jestProject/src/index.test.js',
+          '/home/user/workspace/jestProject/jest.config.js',
+        ],
+        [
+          'linux',
+          'configPath is a relative path, projectPath is not set',
+          'returned path is resolved against workspace path',
+          '/home/user/workspace',
+          undefined,
+          './jest.config.js',
+          '/home/user/workspace/jestProject/src/index.test.js',
+          '/home/user/workspace/jest.config.js',
+        ],
+
+        [
+          'windows',
+          'configPath is an absolute path (with \\)',
+          'returned path is only the specified config path',
+          'C:/workspace',
+          './jestProject',
+          'C:\\notWorkspace\\notJestProject\\jest.config.js',
+          'C:/workspace/jestProject/src/index.test.js',
+          'C:/notWorkspace/notJestProject/jest.config.js',
+        ],
+        [
+          'windows',
+          'configPath is an absolute path (with /)',
+          'returned path is only the (normalized) specified config path',
+          'C:/workspace',
+          './jestProject',
+          'C:/notWorkspace/notJestProject/jest.config.js',
+          'C:/workspace/jestProject/src/index.test.js',
+          'C:/notWorkspace/notJestProject/jest.config.js',
+        ],
+        [
+          'windows',
+          'configPath is a relative path, project path is set',
+          'returned path is resolved against workspace and project path',
+          'C:/workspace',
+          './jestProject',
+          './jest.config.js',
+          'C:/workspace/jestProject/src/index.test.js',
+          'C:/workspace/jestProject/jest.config.js',
+        ],
+        [
+          'windows',
+          'configPath is a relative path, projectPath is not set',
+          'returned path is resolved against workspace path',
+          'C:/workspace',
+          undefined,
+          './jest.config.js',
+          'C:/workspace/jestProject/src/index.test.js',
+          'C:/workspace/jest.config.js',
+        ],
+      ];
+      describe.each(scenarios)(
+        '%s: %s',
+        (_os, _name, behavior, workspacePath, projectPath, configPath, targetPath, expectedPath) => {
+          let jestRunnerConfig: JestRunnerConfig;
+
+          beforeEach(() => {
+            jestRunnerConfig = new JestRunnerConfig();
+            jest
+              .spyOn(vscode.workspace, 'getWorkspaceFolder')
+              .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+          });
+
+          its[_os](behavior, async () => {
+            jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+              new WorkspaceConfiguration({
+                'jestrunner.projectPath': projectPath,
+                'jestrunner.configPath': configPath,
+              }),
+            );
+
+            expect(jestRunnerConfig.getJestConfigPath(targetPath)).toBe(expectedPath);
+          });
+        },
+      );
+    });
+    describe('configPath is a glob map', () => {
+      describe('there is a matching glob', () => {
+        const scenarios: Array<
+          [
+            os: 'windows' | 'linux',
+            name: string,
+            behavior: string,
+            workspacePath: string,
+            projectPath: string | undefined,
+            configPath: Record<string, string>,
+            targetPath: string,
+            expectedPath: string,
+          ]
+        > = [
+          [
+            'linux',
+            'matched glob specifies an absolute path',
+            'returned path is only the specified config path',
+            '/home/user/workspace',
+            './jestProject',
+            { '**/*.test.js': '/home/user/workspace/jestProject/jest.config.js' },
+            '/home/user/workspace/jestProject/src/index.test.js',
+            '/home/user/workspace/jestProject/jest.config.js',
+          ],
+          [
+            'linux',
+            'matched glob specifies a relative path',
+            'returned path is resolved against workspace and project path',
+            '/home/user/workspace',
+            './jestProject',
+            { '**/*.test.js': './jest.config.js' },
+            '/home/user/workspace/jestProject/src/index.test.js',
+            '/home/user/workspace/jestProject/jest.config.js',
+          ],
+          [
+            'linux',
+            'matched glob specifies a relative path, projectPath is not set',
+            'returned path is resolved against workspace path',
+            '/home/user/workspace',
+            undefined,
+            { '**/*.test.js': './jest.config.js' },
+            '/home/user/workspace/jestProject/src/index.test.js',
+            '/home/user/workspace/jest.config.js',
+          ],
+          [
+            'linux',
+            'first matched glob takes precedence, relative path',
+            'returned path is resolved against workspace and project path',
+            '/home/user/workspace',
+            './jestProject',
+            {
+              '**/*.test.js': './jest.config.js',
+              '**/*.spec.js': './jest.unit-config.js',
+              '**/*.it.spec.js': './jest.it-config.js',
+            },
+            '/home/user/workspace/jestProject/src/index.it.spec.js',
+            '/home/user/workspace/jestProject/jest.unit-config.js',
+          ],
+          [
+            'linux',
+            'first matched glob takes precedence, absolute path',
+            'returned path is only the specified config path',
+            '/home/user/workspace',
+            './jestProject',
+            {
+              '**/*.test.js': '/home/user/notWorkspace/notJestProject/jest.config.js',
+              '**/*.spec.js': '/home/user/notWorkspace/notJestProject/jest.unit-config.js',
+              '**/*.it.spec.js': '/home/user/notWorkspace/notJestProject/jest.it-config.js',
+            },
+            '/home/user/workspace/jestProject/src/index.it.spec.js',
+            '/home/user/notWorkspace/notJestProject/jest.unit-config.js',
+          ],
+          // windows
+          [
+            'windows',
+            'matched glob specifies an absolute path (with \\)',
+            'returned path is only the specified (normalized) config path',
+            'C:/workspace',
+            './jestProject',
+            { '**/*.test.js': 'C:\\notWorkspace\\notJestProject\\jest.config.js' },
+            'C:/workspace/jestProject/src/index.test.js',
+            'C:/notWorkspace/notJestProject/jest.config.js',
+          ],
+          [
+            'windows',
+            'matched glob specifies an absolute path (with /)',
+            'returned path is only the specified config path',
+            'C:/workspace',
+            './jestProject',
+            { '**/*.test.js': 'C:/notWorkspace/notJestProject/jest.config.js' },
+            'C:/workspace/jestProject/src/index.test.js',
+            'C:/notWorkspace/notJestProject/jest.config.js',
+          ],
+          [
+            'windows',
+            'matched glob specifies a relative path, projectPath is set',
+            'returned path is resolved against workspace and project path',
+            'C:/workspace',
+            './jestProject',
+            { '**/*.test.js': './jest.config.js' },
+            'C:/workspace/jestProject/src/index.test.js',
+            'C:/workspace/jestProject/jest.config.js',
+          ],
+          [
+            'windows',
+            'matched glob specifies a relative path, projectPath is not set',
+            'returned path is resolved against workspace path',
+            'C:/workspace',
+            undefined,
+            { '**/*.test.js': './jest.config.js' },
+            'C:/workspace/jestProject/src/index.test.js',
+            'C:/workspace/jest.config.js',
+          ],
+          [
+            'windows',
+            'first matched glob takes precedence, relative path',
+            'returned path is resolved against workspace and project path',
+            'C:\\workspace',
+            './jestProject',
+            {
+              '**/*.test.js': './jest.config.js',
+              '**/*.spec.js': './jest.unit-config.js',
+              '**/*.it.spec.js': './jest.it-config.js',
+            },
+            'C:/workspace/jestProject/src/index.it.spec.js',
+            'C:/workspace/jestProject/jest.unit-config.js',
+          ],
+          [
+            'windows',
+            'first matched glob takes precedence, absolute path (with \\)',
+            'returned path is only the (normalized) specified config path',
+            'C:/workspace',
+            './jestProject',
+            {
+              '**/*.test.js': 'C:\\notWorkspace\\notJestProject\\jest.config.js',
+              '**/*.spec.js': 'C:\\notWorkspace\\notJestProject\\jest.unit-config.js',
+              '**/*.it.spec.js': 'C:\\notWorkspace\\notJestProject\\jest.it-config.js',
+            },
+            'C:/workspace/jestProject/src/index.it.spec.js',
+            'C:/notWorkspace/notJestProject/jest.unit-config.js',
+          ],
+          [
+            'windows',
+            'first matched glob takes precedence, absolute path (with /)',
+            'returned path is only the specified config path',
+            'C:/workspace',
+            './jestProject',
+            {
+              '**/*.test.js': 'C:/notWorkspace/notJestProject/jest.config.js',
+              '**/*.spec.js': 'C:/notWorkspace/notJestProject/jest.unit-config.js',
+              '**/*.it.spec.js': 'C:/notWorkspace/notJestProject/jest.it-config.js',
+            },
+            'C:/workspace/jestProject/src/index.it.spec.js',
+            'C:/notWorkspace/notJestProject/jest.unit-config.js',
+          ],
+        ];
+        describe.each(scenarios)(
+          '%s: %s',
+          (_os, _name, behavior, workspacePath, projectPath, configPath, targetPath, expectedPath) => {
+            let jestRunnerConfig: JestRunnerConfig;
+
+            beforeEach(() => {
+              jestRunnerConfig = new JestRunnerConfig();
+              jest
+                .spyOn(vscode.workspace, 'getWorkspaceFolder')
+                .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+            });
+
+            its[_os](behavior, async () => {
+              jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+                new WorkspaceConfiguration({
+                  'jestrunner.projectPath': projectPath,
+                  'jestrunner.configPath': configPath,
+                }),
+              );
+
+              expect(jestRunnerConfig.getJestConfigPath(targetPath)).toBe(expectedPath);
+            });
+          },
+        );
+      });
+
+      describe('no matching glob', () => {
+        const scenarios: Array<
+          [
+            os: 'windows' | 'linux',
+            name: string,
+            behavior: string,
+            workspacePath: string,
+            projectPath: string | undefined,
+            configPath: Record<string, string>,
+            targetPath: string,
+            foundPath: string,
+            expectedPath: string,
+          ]
+        > = [
+          [
+            'linux',
+            'projectPath is relative',
+            'returns the found jest config path (traversing up from target path)',
+            '/home/user/workspace',
+            './jestProject',
+            {
+              '**/*.test.js': './jest.config.js',
+            },
+            '/home/user/workspace/jestProject/src/index.unit.spec.js',
+            '/home/user/workspace/jestProject/jest.config.mjs',
+            '/home/user/workspace/jestProject/jest.config.mjs',
+          ],
+          [
+            'linux',
+            'projectPath is not set',
+            'returns the found jest config path (traversing up from target path)',
+            '/home/user/workspace',
+            undefined,
+            {
+              '**/*.test.js': './jest.config.js',
+            },
+            '/home/user/workspace/src/index.unit.spec.js',
+            '/home/user/workspace/jest.config.mjs',
+            '/home/user/workspace/jest.config.mjs',
+          ],
+          // windows
+
+          [
+            'windows',
+            'projectPath is relative',
+            'returns the found jest config (traversing up from target path)',
+            'C:\\workspace',
+            './jestProject',
+            {
+              '**/*.test.js': 'C:/notWorkspace/notJestProject/jest.config.js',
+            },
+            'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+            'C:\\workspace\\jestProject\\jest.config.mjs',
+            'C:\\workspace\\jestProject\\jest.config.mjs',
+          ],
+          [
+            'windows',
+            'projectPath is not set',
+            'returns the found jest config path (traversing up from target path)',
+            'C:\\workspace',
+            undefined,
+            {
+              '**/*.test.js': 'C:/notWorkspace/notJestProject/jest.config.js',
+            },
+            'C:\\workspace\\src\\index.it.spec.js',
+            'C:\\workspace\\jest.config.mjs',
+            'C:\\workspace\\jest.config.mjs',
+          ],
+        ];
+        describe.each(scenarios)(
+          '%s: %s',
+          (_os, _name, behavior, workspacePath, projectPath, configPath, targetPath, foundPath, expectedPath) => {
+            let jestRunnerConfig: JestRunnerConfig;
+
+            beforeEach(() => {
+              jestRunnerConfig = new JestRunnerConfig();
+              jest
+                .spyOn(vscode.workspace, 'getWorkspaceFolder')
+                .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+              jest.spyOn(vscode.window, 'showWarningMessage').mockReturnValue(undefined);
+              jest.spyOn(fs, 'statSync').mockImplementation((path: string): any => ({
+                isDirectory: () => /\.[a-z]{2,4}$/.test(path),
+              }));
+            });
+
+            its[_os](behavior, async () => {
+              jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+                new WorkspaceConfiguration({
+                  'jestrunner.projectPath': projectPath,
+                  'jestrunner.configPath': configPath,
+                }),
+              );
+              jest.spyOn(fs, 'existsSync').mockImplementation((filePath) => filePath === foundPath);
+
+              expect(jestRunnerConfig.getJestConfigPath(targetPath)).toBe(expectedPath);
+            });
+          },
+        );
+      });
+    });
+  });
+
+  describe('currentPackagePath', () => {
+    const scenarios: Array<
+      [
+        os: 'windows' | 'linux',
+        name: string,
+        behavior: string,
+        workspacePath: string,
+        openedFilePath: string,
+        installedPath: string | undefined,
+      ]
+    > = [
+      [
+        'linux',
+        'jest dep installed in same path as the opened file',
+        'returns the folder path of the opened file',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/index.test.js',
+        '/home/user/workspace/jestProject',
+      ],
+      [
+        'linux',
+        'jest dep installed in parent path of the opened file',
+        'returns the folder path of the parent of the opened file',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/src/index.test.js',
+        '/home/user/workspace/jestProject',
+      ],
+      [
+        'linux',
+        'jest dep installed in an ancestor path of the opened file',
+        'returns the folder path of the ancestor of the opened file',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/deeply/nested/package/src/index.test.js',
+        '/home/user/workspace/jestProject',
+      ],
+      [
+        'linux',
+        'jest dep installed in the workspace of the opened file',
+        "returns the folder path of the opened file's workspace",
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/deeply/nested/package/src/index.test.js',
+        '/home/user/workspace',
+      ],
+      [
+        'linux',
+        'jest dep not installed',
+        'returns empty string',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/deeply/nested/package/src/index.test.js',
+        undefined,
+      ],
+      // windows
+      [
+        'windows',
+        'jest dep installed in same path as the opened file',
+        'returns the folder path of the opened file',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        'C:\\workspace\\jestProject\\src',
+      ],
+      [
+        'windows',
+        'jest dep installed in parent path of the opened file',
+        'returns the folder path of the parent of the opened file',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        'C:\\workspace\\jestProject',
+      ],
+      [
+        'windows',
+        'jest dep installed in an ancestor path of the opened file',
+        'returns the folder path of the ancestor of the opened file',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\deeply\\nested\\package\\src\\index.it.spec.js',
+        'C:\\workspace\\jestProject',
+      ],
+      [
+        'windows',
+        'jest dep installed in the workspace of the opened file',
+        "returns the folder path of the opened file's workspace",
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        'C:\\workspace',
+      ],
+      [
+        'windows',
+        'jest dep not installed',
+        'returns empty string',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        undefined,
+      ],
+    ];
+
+    describe.each(scenarios)('%s: %s', (_os, _name, behavior, workspacePath, openedFilePath, installedPath) => {
+      let jestRunnerConfig: JestRunnerConfig;
+      let packagePath: string;
+      let modulePath: string;
+
+      beforeEach(() => {
+        jestRunnerConfig = new JestRunnerConfig();
+        packagePath = installedPath ? path.resolve(installedPath, 'package.json') : '';
+        modulePath = installedPath ? path.resolve(installedPath, 'node_modules', 'jest') : '';
+        jest
+          .spyOn(vscode.workspace, 'getWorkspaceFolder')
+          .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+        jest
+          .spyOn(vscode.window, 'activeTextEditor', 'get')
+          .mockReturnValue(new TextEditor(new Document(new Uri(openedFilePath))) as any);
+        jest.spyOn(fs, 'statSync').mockImplementation((path): any => ({
+          isDirectory: () => !openedFilePath.endsWith('.ts'),
+        }));
+        jest
+          .spyOn(fs, 'existsSync')
+          .mockImplementation((filePath) => filePath === packagePath || filePath === modulePath);
+        jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+          new WorkspaceConfiguration({
+            'jestrunner.checkRelativePathForJest': false,
+          }),
+        );
+      });
+
+      its[_os](behavior, async () => {
+        if (installedPath) {
+          expect(jestRunnerConfig.currentPackagePath).toBe(installedPath);
+        } else {
+          expect(jestRunnerConfig.currentPackagePath).toBe('');
+        }
+      });
+
+      describe('checkRelativePathForJest is set to true', () => {
+        beforeEach(() => {
+          jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+            new WorkspaceConfiguration({
+              'jestrunner.checkRelativePathForJest': true,
+            }),
+          );
+        });
+
+        its[_os](behavior, async () => {
+          if (installedPath) {
+            expect(jestRunnerConfig.currentPackagePath).toBe(installedPath);
+          } else {
+            expect(jestRunnerConfig.currentPackagePath).toBe('');
+          }
+        });
+      });
+    });
+  });
+  describe('findConfigPath', () => {
+    const scenarios: Array<
+      [
+        os: 'windows' | 'linux',
+        name: string,
+        behavior: string,
+        workspacePath: string,
+        openedFilePath: string,
+        configPath: string | undefined,
+        configFileName: string | undefined,
+      ]
+    > = [
+      [
+        'linux',
+        'jest config located in same path as the opened file',
+        'returns the filename path of the found config file',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/index.test.js',
+        '/home/user/workspace/jestProject',
+        'jest.config.cjs',
+      ],
+      [
+        'linux',
+        'jest config located in parent path of the opened file',
+        'returns the filename path of the found config file',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/src/index.test.js',
+        '/home/user/workspace/jestProject',
+        'jest.config.json',
+      ],
+      [
+        'linux',
+        'jest config located in an ancestor path of the opened file',
+        'returns the filename path of the found config file',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/deeply/nested/package/src/index.test.js',
+        '/home/user/workspace/jestProject',
+        'jest.config.js',
+      ],
+      [
+        'linux',
+        'jest config located in the workspace of the opened file',
+        'returns the filename path of the found config file',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/deeply/nested/package/src/index.test.js',
+        '/home/user/workspace',
+        'jest.config.ts',
+      ],
+      [
+        'linux',
+        'jest config not located',
+        'returns empty string',
+        '/home/user/workspace',
+        '/home/user/workspace/jestProject/deeply/nested/package/src/index.test.js',
+        undefined,
+        undefined,
+      ],
+      // windows
+      [
+        'windows',
+        'jest config located in same path as the opened file',
+        'returns the (normalized) folder path of the opened file',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        'C:\\workspace\\jestProject\\src',
+        'jest.config.cjs',
+      ],
+      [
+        'windows',
+        'jest config located in parent path of the opened file',
+        'returns the (normalized) folder path of the parent of the opened file',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        'C:\\workspace\\jestProject',
+        'jest.config.json',
+      ],
+      [
+        'windows',
+        'jest config located in an ancestor path of the opened file',
+        'returns the (normalized) folder path of the ancestor of the opened file',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\deeply\\nested\\package\\src\\index.it.spec.js',
+        'C:\\workspace\\jestProject',
+        'jest.config.js',
+      ],
+      [
+        'windows',
+        'jest config located in the workspace of the opened file',
+        "returns the (normalized) folder path of the opened file's workspace",
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        'C:\\workspace',
+        'jest.config.ts',
+      ],
+      [
+        'windows',
+        'jest config not located',
+        'returns empty string',
+        'C:\\workspace',
+        'C:\\workspace\\jestProject\\src\\index.it.spec.js',
+        undefined,
+        undefined,
+      ],
+    ];
+
+    describe('targetPath is not provided', () => {
+      describe.each(scenarios)(
+        '%s: %s',
+        (_os, _name, behavior, workspacePath, openedFilePath, configPath, configFilename) => {
+          let jestRunnerConfig: JestRunnerConfig;
+          let configFilePath: string;
+          let activeTextEditorSpy: jest.SpyInstance;
+
+          beforeEach(() => {
+            jestRunnerConfig = new JestRunnerConfig();
+            configFilePath = configPath && configFilename ? path.resolve(configPath, configFilename) : '';
+            jest
+              .spyOn(vscode.workspace, 'getWorkspaceFolder')
+              .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+            activeTextEditorSpy = jest
+              .spyOn(vscode.window, 'activeTextEditor', 'get')
+              .mockReturnValue(new TextEditor(new Document(new Uri(openedFilePath))) as any);
+            jest.spyOn(fs, 'existsSync').mockImplementation((filePath) => filePath === configFilePath);
+            jest.spyOn(fs, 'statSync').mockImplementation((path): any => ({
+              isDirectory: () => !openedFilePath.endsWith('.ts'),
+            }));
+          });
+
+          its[_os](behavior, async () => {
+            if (configPath) {
+              expect(jestRunnerConfig.findConfigPath()).toBe(normalizePath(configFilePath));
+            } else {
+              expect(jestRunnerConfig.findConfigPath()).toBe('');
+            }
+            expect(activeTextEditorSpy).toBeCalled();
+          });
+        },
+      );
+    });
+    describe('targetPath is provided', () => {
+      describe.each(scenarios)(
+        '%s: %s',
+        (_os, _name, behavior, workspacePath, openedFilePath, configPath, configFilename) => {
+          let jestRunnerConfig: JestRunnerConfig;
+          let configFilePath: string;
+
+          beforeEach(() => {
+            jestRunnerConfig = new JestRunnerConfig();
+            configFilePath = configPath && configFilename ? path.resolve(configPath, configFilename) : '';
+            jest.spyOn(vscode.window, 'activeTextEditor', 'get');
+            jest
+              .spyOn(vscode.workspace, 'getWorkspaceFolder')
+              .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+            jest.spyOn(fs, 'existsSync').mockImplementation((filePath) => filePath === configFilePath);
+            jest.spyOn(fs, 'statSync').mockImplementation((path): any => ({
+              isDirectory: () => !openedFilePath.endsWith('.ts'),
+            }));
+          });
+
+          its[_os](behavior, async () => {
+            if (configPath) {
+              expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBe(configFilePath);
+            } else {
+              expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBe('');
+            }
+          });
+        },
+      );
     });
   });
 });

--- a/src/test/jestRunnerConfig.test.ts
+++ b/src/test/jestRunnerConfig.test.ts
@@ -261,7 +261,7 @@ describe('JestRunnerConfig', () => {
           [
             'windows',
             'matched glob specifies an absolute path (with /)',
-            'returned path is only the specified config path',
+            'returned path is only the specified (normalized) config path',
             'C:/workspace',
             './jestProject',
             { '**/*.test.js': 'C:/notWorkspace/notJestProject/jest.config.js' },
@@ -271,7 +271,7 @@ describe('JestRunnerConfig', () => {
           [
             'windows',
             'matched glob specifies a relative path, projectPath is set',
-            'returned path is resolved against workspace and project path',
+            'returned (normalized) path is resolved against workspace and project path',
             'C:/workspace',
             './jestProject',
             { '**/*.test.js': './jest.config.js' },
@@ -281,7 +281,7 @@ describe('JestRunnerConfig', () => {
           [
             'windows',
             'matched glob specifies a relative path, projectPath is not set',
-            'returned path is resolved against workspace path',
+            'returned (normalized) path is resolved against workspace path',
             'C:/workspace',
             undefined,
             { '**/*.test.js': './jest.config.js' },
@@ -291,7 +291,7 @@ describe('JestRunnerConfig', () => {
           [
             'windows',
             'first matched glob takes precedence, relative path',
-            'returned path is resolved against workspace and project path',
+            'returned(normalized) path is resolved against workspace and project path',
             'C:\\workspace',
             './jestProject',
             {
@@ -305,7 +305,7 @@ describe('JestRunnerConfig', () => {
           [
             'windows',
             'first matched glob takes precedence, absolute path (with \\)',
-            'returned path is only the (normalized) specified config path',
+            'returned (normalized) path is only the (normalized) specified config path',
             'C:/workspace',
             './jestProject',
             {
@@ -319,7 +319,7 @@ describe('JestRunnerConfig', () => {
           [
             'windows',
             'first matched glob takes precedence, absolute path (with /)',
-            'returned path is only the specified config path',
+            'returned (normalized) path is only the specified config path',
             'C:/workspace',
             './jestProject',
             {
@@ -351,7 +351,7 @@ describe('JestRunnerConfig', () => {
                 }),
               );
 
-              expect(jestRunnerConfig.getJestConfigPath(targetPath)).toBe(expectedPath);
+              expect(jestRunnerConfig.getJestConfigPath(targetPath)).toBe(normalizePath(expectedPath));
             });
           },
         );
@@ -402,7 +402,7 @@ describe('JestRunnerConfig', () => {
           [
             'windows',
             'projectPath is relative',
-            'returns the found jest config (traversing up from target path)',
+            'returns the (normalized) found jest config (traversing up from target path)',
             'C:\\workspace',
             './jestProject',
             {
@@ -410,12 +410,12 @@ describe('JestRunnerConfig', () => {
             },
             'C:\\workspace\\jestProject\\src\\index.it.spec.js',
             'C:\\workspace\\jestProject\\jest.config.mjs',
-            'C:\\workspace\\jestProject\\jest.config.mjs',
+            'C:/workspace/jestProject/jest.config.mjs',
           ],
           [
             'windows',
             'projectPath is not set',
-            'returns the found jest config path (traversing up from target path)',
+            'returns the (normalized) found jest config path (traversing up from target path)',
             'C:\\workspace',
             undefined,
             {
@@ -423,7 +423,7 @@ describe('JestRunnerConfig', () => {
             },
             'C:\\workspace\\src\\index.it.spec.js',
             'C:\\workspace\\jest.config.mjs',
-            'C:\\workspace\\jest.config.mjs',
+            'C:/workspace/jest.config.mjs',
           ],
         ];
         describe.each(scenarios)(

--- a/src/test/jestRunnerConfig.test.ts
+++ b/src/test/jestRunnerConfig.test.ts
@@ -769,7 +769,7 @@ describe('JestRunnerConfig', () => {
 
           its[_os](behavior, async () => {
             if (configPath) {
-              expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBe(configFilePath);
+              expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBe(normalizePath(configFilePath));
             } else {
               expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBe('');
             }

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,4 +1,10 @@
-import { validateCodeLensOptions } from '../util';
+import { isWindows, searchPathToParent, validateCodeLensOptions } from '../util';
+import * as fs from 'fs';
+
+const its = {
+  windows: isWindows() ? it : it.skip,
+  linux: ['linux', 'darwin'].includes(process.platform) ? it : it.skip,
+};
 
 describe('validateCodeLensOptions', () =>
   it.each([
@@ -10,3 +16,96 @@ describe('validateCodeLensOptions', () =>
   ])('should turn "jestrunner.codeLens" options  into something valid', (input, expected) => {
     expect(validateCodeLensOptions(input)).toEqual(expected);
   }));
+
+describe('searchPathToParent', () => {
+  const scenarios: Array<
+    [os: string, fileAsStartPath: string, folderAsStartPath: string, workspacePath: string, traversedPaths: string[]]
+  > = [
+    [
+      'linux',
+      '/home/user/workspace/package/src/file.ts',
+      '/home/user/workspace/package/src',
+      '/home/user/workspace',
+      ['/home/user/workspace/package/src', '/home/user/workspace/package', '/home/user/workspace'],
+    ],
+    [
+      'windows',
+      'C:\\Users\\user\\workspace\\package\\src\\file.ts',
+      'C:\\Users\\user\\workspace\\package\\src',
+      'C:\\Users\\user\\workspace',
+      ['C:\\Users\\user\\workspace\\package\\src', 'C:\\Users\\user\\workspace\\package', 'C:\\Users\\user\\workspace'],
+    ],
+  ];
+  describe.each(scenarios)('on %s', (os, fileAsStartPath, folderAsStartPath, workspacePath, traversedPaths) => {
+    // const fileAsStartPath = '/home/user/workspace/package/src/file.ts';
+    // const folderAsStartPath = '/home/user/workspace/package/src';
+    // const workspacePath = '/home/user/workspace';
+    // const traversedPaths = ['/home/user/workspace/package/src', '/home/user/workspace/package', '/home/user/workspace'];
+    beforeEach(() => {
+      jest.spyOn(fs, 'statSync').mockImplementation((path): any => {
+        if (path === fileAsStartPath) {
+          return { isFile: () => true, isDirectory: () => false };
+        }
+        return { isFile: () => false, isDirectory: () => true };
+      });
+    });
+
+    its[os]('starts traversal at the starting (directory) path', () => {
+      const mockCallback = jest.fn().mockReturnValue('found');
+      searchPathToParent(folderAsStartPath, workspacePath, mockCallback);
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith(traversedPaths[0]);
+    });
+    its[os]('starts traversal at the folder of the starting (file) path', () => {
+      const mockCallback = jest.fn().mockReturnValue('found');
+      searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+      expect(mockCallback).toHaveBeenCalledWith(traversedPaths[0]);
+    });
+    its[os]('traverses up to and includes the ancestor path', () => {
+      const mockCallback = jest.fn().mockReturnValue(false);
+      searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(mockCallback).toHaveBeenCalledTimes(traversedPaths.length);
+      for (const path of traversedPaths) {
+        expect(mockCallback).toHaveBeenCalledWith(path);
+      }
+    });
+    its[os]('continues traversal if callback returns 0', () => {
+      const mockCallback = jest.fn().mockReturnValue(0);
+      const result = searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(result).toBe(false);
+    });
+    its[os]('continues traversal if callback returns null', () => {
+      const mockCallback = jest.fn().mockReturnValue(null);
+      const result = searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(result).toBe(false);
+    });
+    its[os]('continues traversal if callback returns void (undefined)', () => {
+      const mockCallback = jest.fn().mockReturnValue(undefined);
+      const result = searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(result).toBe(false);
+    });
+    its[os]('continues traversal if callback returns false', () => {
+      const mockCallback = jest.fn().mockReturnValue(undefined);
+      const result = searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(result).toBe(false);
+    });
+    its[os]('it stops traversal when the callback returns a string', () => {
+      const mockCallback = jest.fn().mockReturnValueOnce(false).mockReturnValue('found');
+      searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(mockCallback).toHaveBeenCalledTimes(2);
+      expect(mockCallback).toHaveBeenCalledWith(traversedPaths[0]);
+      expect(mockCallback).toHaveBeenCalledWith(traversedPaths[1]);
+    });
+    its[os]('returns the non-falsy value returned by the callback', () => {
+      const mockCallback = jest.fn().mockReturnValueOnce(false).mockReturnValue('found');
+      const result = searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(result).toBe('found');
+    });
+    its[os]('returns false if the traversal completes without the callback returning a string', () => {
+      const mockCallback = jest.fn().mockReturnValue(false);
+      const result = searchPathToParent(fileAsStartPath, workspacePath, mockCallback);
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Hi all. Scratching a personal itch that at least [a couple others seem interested in](https://github.com/firsttris/vscode-jest-runner/issues/309).

Adds the ability to specify a glob mapping for jest runner such as:
```json
{
  "jestrunner.configPath": {
    "**/*.it.spec.ts": "./jest.it.config.js",
    "**/*.spec.ts": "./jest.unit.config.js"
  }
}
```

- [x] updated contributes.configuration schema to make jestrunner.configPath be null, string or Record<string,string>
- [x] updated jestRunnerConfig getJestConfig to return path specified for matching glob
- [x] added unit test for configPath glob functionality
  - used a slightly tweaked approach to windows/linux grouping to reduce test boilerplate 
- [x] updated extension readme w/ a blurb about how to use glob map for configPath

Id like to point out that I think the [while loop](https://github.com/firsttris/vscode-jest-runner/blob/930a1776e5b5a77e3f6a6a9111eab7a94d07795b/src/jestRunnerConfig.ts#L107) in JestRunnerConfig's `findConfigPath` is not quite correctly implemented. When implementing my tests for the case that glob match was not found and projectPath was not specified, I **expected** to be able to assert against fs.existSync being called with a jest config in the workspace directory. Alas, the loop terminates before scanning the workspace directory. 

I don't know if this is intentional but it goes counter to my expectations. I made by test pass by asserting against the targetPath directory but I think the function should look in the workspace directory. Note, I'm new to vscode extension development and I'm assuming workspace directory = project root in most cases -- but maybe I'm making an incorrect assumption.. 

