### PR TITLE
feat: Add `jestrunner.useNearestConfig` to find the nearest config when `jestrunner.configPath` is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ out
 node_modules
 coverage
 .vscode-test/
-.vsix
+*.vsix
 dist
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you have a custom setup use the following options to customize Jest Runner:
 | Command                                   | Description                                                                                                                                                 |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | jestrunner.configPath                     | Jest config path (string) (relative to `${workspaceFolder}` e.g. jest-config.json). Defaults to blank. Can also be a glob path mapping. See [below](#configpath-as-glob-map) for more details         |
+| jestrunner.useNearestConfig               | If jestrunner.configPath is set and this is `true`, the nearest matching jest config up the path hierarchy will be used instead of the relative path.       |
 | jestrunner.jestPath                       | Absolute path to jest bin file (e.g. /usr/lib/node_modules/jest/bin/jest.js)                                                                                |
 | jestrunner.debugOptions                   | Add or overwrite vscode debug configurations (only in debug mode) (e.g. `"jestrunner.debugOptions": { "args": ["--no-cache"] }`)                            |
 | jestrunner.runOptions                     | Add CLI Options to the Jest Command (e.g. `"jestrunner.runOptions": ["--coverage", "--colors"]`) https://jestjs.io/docs/en/cli                              |
@@ -64,8 +65,8 @@ If you have a custom setup use the following options to customize Jest Runner:
 | jestrunner.codeLens                       | Choose which CodeLens to enable, default to `["run", "debug"]`                                                                                              |
 | jestrunner.enableYarnPnpSupport           | Enable if you are using Yarn 2 with Plug'n'Play                                                                                                             |
 | jestrunner.yarnPnpCommand                 | Command for debugging with Plug'n'Play defaults to yarn-*.*js                                                                                               |
-| jestrunner.projectPath                    | Absolute path to project directory (e.g. /home/me/project/sub-folder), or relative path to workspace root (e.g. ./sub-folder)                               |
-| jestrunner.checkRelativePathForJest       | When looking for the nearest resolution for Jest, only check for package.json files, rather than the `node_modules` folder.                                 |
+| jestrunner.projectPath                    | Absolute path to project directory (e.g. /home/me/project/sub-folder), or relative path from workspace root (e.g. ./sub-folder)                             |
+| jestrunner.checkRelativePathForJest       | When `false`, when looking for the nearest resolution for Jest, only check for package.json files, rather than the `node_modules` folder. Default: `true`   |
 | jestrunner.changeDirectoryToWorkspaceRoot | Changes directory before execution. The order is:<ol><li>`jestrunner.projectPath`</li><li>the nearest `package.json`</li><li>`${workspaceFolder}`</li></ol> |
 | jestrunner.preserveEditorFocus            | Preserve focus on your editor instead of focusing the terminal on test run                                                                                  |
 | jestrunner.runInExternalNativeTerminal    | run in external terminal (requires: npm install ttab -g)                                                                                                    |
@@ -74,6 +75,7 @@ If you have a custom setup use the following options to customize Jest Runner:
 If you've got multiple jest configs for running tests (ie maybe a config for unit tests, integration tests and frontend tests) then this option is for you. You can provide a map of glob matchers to specify which jest config to use based on the name of the file the test is being run for. 
 
 For instance, supose you're using the naming convention of `*.spec.ts` for unit tests and `*.it.spec.ts` for integration tests. You'd use the following for your configPath setting:
+
 ```json
 {
   "jestrunner.configPath": {
@@ -82,7 +84,12 @@ For instance, supose you're using the naming convention of `*.spec.ts` for unit 
   }
 }
 ```
+
 Note the order we've specified the globs in this example. Because our naming convention has a little overlap, we need to specify the more narrow glob first because jestrunner will return the config path of the first matching glob. With the above order, we make certain that `jest.it.config.js` will be used for any file ending with `.it.spec.ts` and `jest.unit.config.js` will be used for files that only end in `*.spec.ts` (without `.it.`).  If we had reversed the order, `jest.unit.config.js` would be used for both `*.it.spec.ts` and `*.spec.ts` endings the glob matches both. 
+
+By default, the config path is relative to `{jestrunner.projectPath}` if configured, otherwise the workspace root. 
+
+To find the nearest config matching the result from the `jestrunner.configPath` map, set `"jestrunner.useNearestConfig": true`. When `true`, vscode-jest-runner will search up the through directories from the target until it finds the matching file. For instance, running tests in `~/dev/my-repo/packages/project1/__test__/integration/ship-it.it.spec.ts` will use `~/dev/my-repo/packages/project1/jest.it.config.js` rather than the config in the monorepo's root.
 
 ## Shortcuts
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,12 @@
             "default": "",
             "scope": "window"
           },
+          "jestrunner.useNearestConfig": {
+            "type": "boolean",
+            "default": false,
+            "description": "If jestrunner.configPath is set and this is true, the nearest matching jest config in the path hierarchy will be used instead of the root path.",
+            "scope": "window"
+          },
           "jestrunner.jestPath": {
             "type": "string",
             "default": "",
@@ -121,7 +127,7 @@
           "jestrunner.checkRelativePathForJest": {
             "type": "boolean",
             "default": true,
-            "description": "When looking for the nearest resolution for Jest, only check for package.json files, rather than the `node_modules` folder.",
+            "description": "When `false`, when looking for the nearest resolution for Jest, only check for package.json files, rather than the `node_modules` folder.",
             "scope": "window"
           },
           "jestrunner.changeDirectoryToWorkspaceRoot": {

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -32,6 +32,7 @@ class Workspace {
 type JestRunnerConfigProps = {
   'jestrunner.projectPath'?: string;
   'jestrunner.configPath'?: string | Record<string, string>;
+  'jestrunner.useNearestConfig'?: boolean;
   'jestrunner.checkRelativePathForJest'?: boolean;
 };
 class WorkspaceConfiguration {

--- a/src/test/jestRunnerConfig.test.ts
+++ b/src/test/jestRunnerConfig.test.ts
@@ -152,7 +152,17 @@ describe('JestRunnerConfig', () => {
       ];
       describe.each(scenarios)(
         '%s: %s',
-        (_os, _name, behavior, workspacePath, projectPath, configPath, targetPath, expectedPath) => {
+        (
+          _os,
+          _name,
+          behavior,
+          workspacePath,
+          projectPath,
+          configPath,
+          targetPath,
+          expectedPath,
+          useNearestConfig = undefined,
+        ) => {
           let jestRunnerConfig: JestRunnerConfig;
 
           beforeEach(() => {
@@ -167,6 +177,7 @@ describe('JestRunnerConfig', () => {
               new WorkspaceConfiguration({
                 'jestrunner.projectPath': projectPath,
                 'jestrunner.configPath': configPath,
+                'jestrunner.useNearestConfig': useNearestConfig,
               }),
             );
 
@@ -187,6 +198,7 @@ describe('JestRunnerConfig', () => {
             configPath: Record<string, string>,
             targetPath: string,
             expectedPath: string,
+            useNearestConfig?: boolean,
           ]
         > = [
           [
@@ -221,6 +233,17 @@ describe('JestRunnerConfig', () => {
           ],
           [
             'linux',
+            'matched glob specifies a relative path, useNearestConfig is true',
+            'returned path is the nearest config in project',
+            '/home/user/workspace',
+            undefined,
+            { '**/*.test.js': './jest.config.js' },
+            '/home/user/workspace/jestProject/src/index.test.js',
+            '/home/user/workspace/jestProject/jest.config.js',
+            true,
+          ],
+          [
+            'linux',
             'first matched glob takes precedence, relative path',
             'returned path is resolved against workspace and project path',
             '/home/user/workspace',
@@ -235,6 +258,21 @@ describe('JestRunnerConfig', () => {
           ],
           [
             'linux',
+            'first matched glob takes precedence, relative path, useNearestConfig is true',
+            'returned path is the nearest config in project',
+            '/home/user/workspace',
+            './aDifferentProject',
+            {
+              '**/*.test.js': './jest.config.js',
+              '**/*.spec.js': './jest.unit-config.js',
+              '**/*.it.spec.js': './jest.it-config.js',
+            },
+            '/home/user/workspace/jestProject/src/index.it.spec.js',
+            '/home/user/workspace/jestProject/jest.unit-config.js',
+            true,
+          ],
+          [
+            'linux',
             'first matched glob takes precedence, absolute path',
             'returned path is only the specified config path',
             '/home/user/workspace',
@@ -246,6 +284,21 @@ describe('JestRunnerConfig', () => {
             },
             '/home/user/workspace/jestProject/src/index.it.spec.js',
             '/home/user/notWorkspace/notJestProject/jest.unit-config.js',
+          ],
+          [
+            'linux',
+            'first matched glob takes precedence, useNearestConfig falls back to absolute path',
+            'returned path is only the specified config path',
+            '/home/user/workspace',
+            './jestProject',
+            {
+              '**/*.test.js': '/home/user/notWorkspace/notJestProject/jest.config.js',
+              '**/*.spec.js': '/home/user/notWorkspace/notJestProject/jest.unit-config.js',
+              '**/*.it.spec.js': '/home/user/notWorkspace/notJestProject/jest.it-config.js',
+            },
+            '/home/user/workspace/jestProject/src/index.it.spec.js',
+            '/home/user/notWorkspace/notJestProject/jest.unit-config.js',
+            true,
           ],
           // windows
           [
@@ -290,6 +343,17 @@ describe('JestRunnerConfig', () => {
           ],
           [
             'windows',
+            'matched glob specifies a relative path, useNearestConfig is true',
+            'returned path is the nearest config in project',
+            'C:/workspace',
+            undefined,
+            { '**/*.test.js': './jest.config.js' },
+            'C:/workspace/jestProject/src/index.test.js',
+            'C:/workspace/jestProject/jest.config.js',
+            true,
+          ],
+          [
+            'windows',
             'first matched glob takes precedence, relative path',
             'returned(normalized) path is resolved against workspace and project path',
             'C:\\workspace',
@@ -301,6 +365,21 @@ describe('JestRunnerConfig', () => {
             },
             'C:/workspace/jestProject/src/index.it.spec.js',
             'C:/workspace/jestProject/jest.unit-config.js',
+          ],
+          [
+            'windows',
+            'first matched glob takes precedence, relative path, useNearestConfig is true',
+            'returned path is the nearest config in project',
+            'C:/workspace',
+            './aDifferentProject',
+            {
+              '**/*.test.js': './jest.config.js',
+              '**/*.spec.js': './jest.unit-config.js',
+              '**/*.it.spec.js': './jest.it-config.js',
+            },
+            'C:/workspace/jestProject/src/index.it.spec.js',
+            'C:/workspace/jestProject/jest.unit-config.js',
+            true,
           ],
           [
             'windows',
@@ -330,10 +409,35 @@ describe('JestRunnerConfig', () => {
             'C:/workspace/jestProject/src/index.it.spec.js',
             'C:/notWorkspace/notJestProject/jest.unit-config.js',
           ],
+          [
+            'windows',
+            'first matched glob takes precedence, useNearestConfig falls back to absolute path',
+            'returned path is only the specified config path',
+            'C:/workspace',
+            './jestProject',
+            {
+              '**/*.test.js': '/home/user/notWorkspace/notJestProject/jest.config.js',
+              '**/*.spec.js': '/home/user/notWorkspace/notJestProject/jest.unit-config.js',
+              '**/*.it.spec.js': '/home/user/notWorkspace/notJestProject/jest.it-config.js',
+            },
+            'C:/workspace/jestProject/src/index.it.spec.js',
+            'C:/notWorkspace/notJestProject/jest.unit-config.js',
+            true,
+          ],
         ];
         describe.each(scenarios)(
           '%s: %s',
-          (_os, _name, behavior, workspacePath, projectPath, configPath, targetPath, expectedPath) => {
+          (
+            _os,
+            _name,
+            behavior,
+            workspacePath,
+            projectPath,
+            configPath,
+            targetPath,
+            expectedPath,
+            useNearestConfig = undefined,
+          ) => {
             let jestRunnerConfig: JestRunnerConfig;
 
             beforeEach(() => {
@@ -341,6 +445,14 @@ describe('JestRunnerConfig', () => {
               jest
                 .spyOn(vscode.workspace, 'getWorkspaceFolder')
                 .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+              jest.spyOn(fs, 'statSync').mockImplementation((path): any => {
+                if (path === targetPath) {
+                  return { isFile: () => true, isDirectory: () => false };
+                }
+                return { isFile: () => false, isDirectory: () => true };
+              });
+              // Return true if getJestConfigPath is checking the expected path
+              jest.spyOn(fs, 'existsSync').mockImplementation((filePath) => filePath === expectedPath);
             });
 
             its[_os](behavior, async () => {
@@ -348,6 +460,7 @@ describe('JestRunnerConfig', () => {
                 new WorkspaceConfiguration({
                   'jestrunner.projectPath': projectPath,
                   'jestrunner.configPath': configPath,
+                  'jestrunner.useNearestConfig': useNearestConfig,
                 }),
               );
 
@@ -398,7 +511,6 @@ describe('JestRunnerConfig', () => {
             '/home/user/workspace/jest.config.mjs',
           ],
           // windows
-
           [
             'windows',
             'projectPath is relative',
@@ -456,6 +568,126 @@ describe('JestRunnerConfig', () => {
           },
         );
       });
+    });
+    describe('configPath is not set', () => {
+      const scenarios: Array<
+        [
+          os: 'windows' | 'linux',
+          name: string,
+          behavior: string,
+          workspacePath: string,
+          projectPath: string | undefined,
+          targetPath: string,
+          expectedPath: string,
+        ]
+      > = [
+        [
+          'linux',
+          'without project path',
+          'returns the found jest config path (traversing up from target path)',
+          '/home/user/workspace',
+          undefined,
+          '/home/user/workspace/jestProject/src/index.unit.spec.js',
+          '/home/user/workspace/jestProject/jest.config.mjs',
+        ],
+        [
+          'linux',
+          'with projectPath defined',
+          'returns the found jest config path (traversing up from target path)',
+          '/home/user/workspace',
+          './anotherProject',
+          '/home/user/workspace/jestProject/src/index.unit.spec.js',
+          '/home/user/workspace/jestProject/jest.config.mjs',
+        ],
+        [
+          'linux',
+          'with projectPath defined and no config in project',
+          'returns the found jest config path in workspace (traversing up from target path)',
+          '/home/user/workspace',
+          './anotherProject',
+          '/home/user/workspace/anotherProject/src/index.unit.spec.js',
+          '/home/user/workspace/jest.config.mjs',
+        ],
+        [
+          'linux',
+          'with no configs found',
+          'returns an empty string',
+          '/home/user/workspace',
+          './anotherProject',
+          '/home/user/workspace/anotherProject/src/index.unit.spec.js',
+          '',
+        ],
+        // windows
+        [
+          'windows',
+          'without project path',
+          'returns the found jest config path (traversing up from target path)',
+          'C:\\workspace',
+          undefined,
+          'C:\\workspace\\jestProject\\src\\index.unit.spec.js',
+          'C:\\workspace\\jestProject\\jest.config.mjs',
+        ],
+        [
+          'windows',
+          'with projectPath defined',
+          'returns the found jest config path (traversing up from target path)',
+          'C:\\workspace',
+          './anotherProject',
+          'C:\\workspace\\jestProject\\src\\index.unit.spec.js',
+          'C:\\workspace\\jestProject\\jest.config.mjs',
+        ],
+        [
+          'windows',
+          'with projectPath defined and no config in project',
+          'returns the found jest config path in workspace (traversing up from target path)',
+          'C:\\workspace',
+          './anotherProject',
+          'C:\\workspace\\anotherProject\\src\\index.unit.spec.js',
+          'C:\\workspace\\jest.config.mjs',
+        ],
+        [
+          'windows',
+          'with no configs found',
+          'returns an empty string',
+          'C:\\workspace',
+          './anotherProject',
+          'C:\\workspace\\anotherProject\\src\\index.unit.spec.js',
+          '',
+        ],
+      ];
+      describe.each(scenarios)(
+        '%s: %s',
+        (_os, _name, behavior, workspacePath, projectPath, targetPath, expectedPath) => {
+          let jestRunnerConfig: JestRunnerConfig;
+
+          beforeEach(() => {
+            jestRunnerConfig = new JestRunnerConfig();
+            jest
+              .spyOn(vscode.workspace, 'getWorkspaceFolder')
+              .mockReturnValue(new WorkspaceFolder(new Uri(workspacePath) as any) as any);
+
+            jest.spyOn(fs, 'statSync').mockImplementation((path): any => {
+              if (path === targetPath) {
+                return { isFile: () => true, isDirectory: () => false };
+              }
+              return { isFile: () => false, isDirectory: () => true };
+            });
+            // Return true if getJestConfigPath is checking the expected path
+            jest.spyOn(fs, 'existsSync').mockImplementation((filePath) => filePath === expectedPath);
+          });
+
+          its[_os](behavior, async () => {
+            jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+              new WorkspaceConfiguration({
+                'jestrunner.projectPath': projectPath,
+                'jestrunner.configPath': undefined,
+              }),
+            );
+
+            expect(jestRunnerConfig.getJestConfigPath(targetPath)).toBe(expectedPath);
+          });
+        },
+      );
     });
   });
 
@@ -740,7 +972,7 @@ describe('JestRunnerConfig', () => {
             if (configPath) {
               expect(jestRunnerConfig.findConfigPath()).toBe(normalizePath(configFilePath));
             } else {
-              expect(jestRunnerConfig.findConfigPath()).toBe('');
+              expect(jestRunnerConfig.findConfigPath()).toBeUndefined();
             }
             expect(activeTextEditorSpy).toBeCalled();
           });
@@ -771,7 +1003,7 @@ describe('JestRunnerConfig', () => {
             if (configPath) {
               expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBe(normalizePath(configFilePath));
             } else {
-              expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBe('');
+              expect(jestRunnerConfig.findConfigPath(openedFilePath)).toBeUndefined();
             }
           });
         },


### PR DESCRIPTION
Adds a `jestrunner.useNearestConfig` to improve using `jestrunner.configPath` maps in a monorepo.

The ability to use glob maps to config file names was introduced in #389.

By default, the path resolved from `jestrunner.configPath` is relative to `{jestrunner.projectPath}` if configured, otherwise the workspace root. 

#400 explains the need to use the nearest matching config in a monorepo.

To find the nearest config matching the result from the `jestrunner.configPath` map, set `"jestrunner.useNearestConfig": true`. When `true`, vscode-jest-runner will search up the through directories from the target until it finds the matching file. For instance, running tests in `~/dev/my-repo/packages/project1/__test__/integration/ship-it.it.spec.ts` will use `~/dev/my-repo/packages/project1/jest.it.config.js` rather than the config in the monorepo's root.

My goal in this implementation was to introduce the option without affecting current functionality.